### PR TITLE
fix: fix authentication error on recent releases of DeepCell

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Pillow>=9.1.0
 opencv-python>=4.5.6
-DeepCell>=0.12.0
+DeepCell==0.12.7
 XlsxWriter>=3.0.0
 screeninfo>=0.7
 numpy>=1.20,<1.24


### PR DESCRIPTION
Now forcing the installation of DeepCell 0.12.7, that does not feature an authentication mechanism.