### PR TITLE
Improve the available settings

### DIFF
--- a/src/myofinder/files_table.py
+++ b/src/myofinder/files_table.py
@@ -294,7 +294,7 @@ class Files_table(ttk.Frame):
         return [entry.path for entry in self.table_items
                 if entry.graph_elt.button_var.get()]
 
-    def delete_image(self, to_delete: Tuple[Path]) -> None:
+    def delete_image(self, to_delete: Tuple[Path, ...]) -> None:
         """Removes images from the canvas, and discards all the associated
         data.
 

--- a/src/myofinder/image_segmentation.py
+++ b/src/myofinder/image_segmentation.py
@@ -29,7 +29,7 @@ class Image_segmentation:
                  fiber_color: str,
                  fiber_threshold: int,
                  nuclei_threshold: int,
-                 small_objects_threshold: int) -> \
+                 minimum_nucleus_diameter: int) -> \
             (Path, List[Tuple[np.ndarray, np.ndarray]],
              List[Tuple[np.ndarray, np.ndarray]], Tuple[Any], float):
         """Computes the nuclei positions and optionally the fibers positions.
@@ -44,7 +44,7 @@ class Image_segmentation:
                 considered to be part of a fiber.
             nuclei_threshold: Any nucleus whose average brightness is lower
                 than this value will be discarded.
-            small_objects_threshold: Objects whose area is lower than this
+            minimum_nucleus_diameter: Objects whose area is lower than this
                 value (in pixels) will not be considered.
 
         Returns:
@@ -82,6 +82,8 @@ class Image_segmentation:
         fill_holes_threshold = 15
         pixel_expansion = None
         maxima_algorith = 'h_maxima'
+
+        small_objects_threshold = minimum_nucleus_diameter ** 2 * np.pi / 4
 
         # Actual nuclei detection function
         labeled_image = self._app.predict(

--- a/src/myofinder/main_window.py
+++ b/src/myofinder/main_window.py
@@ -207,7 +207,7 @@ class Main_window(Tk):
                                                 self._enable_save_button)
         self.settings.nuclei_threshold.trace_add("write",
                                                  self._enable_save_button)
-        self.settings.small_objects_threshold.trace_add(
+        self.settings.minimum_nuc_diameter.trace_add(
             "write", self._enable_save_button)
 
         # Updates the display when an image has been processed
@@ -804,7 +804,7 @@ class Main_window(Tk):
                  self.settings.fiber_colour.get(),
                  self.settings.fiber_threshold.get(),
                  self.settings.nuclei_threshold.get(),
-                 self.settings.small_objects_threshold.get()))
+                 self.settings.minimum_nuc_diameter.get()))
 
     def _process_thread(self) -> None:
         """Main loop of the thread in charge of processing the images.
@@ -839,7 +839,7 @@ class Main_window(Tk):
                 try:
                     job = self._queue.get_nowait()
                     path, nuclei_color, fiber_color, fiber_threshold, \
-                        nuclei_threshold, small_objects_threshold = job
+                        nuclei_threshold, minimum_nucleus_diameter = job
                     self.log(f"Processing thread received job: "
                              f"{', '.join(map(str, job))}")
                 except Empty:
@@ -859,7 +859,7 @@ class Main_window(Tk):
                                            fiber_color,
                                            fiber_threshold,
                                            nuclei_threshold,
-                                           small_objects_threshold)
+                                           minimum_nucleus_diameter)
                     self.log(f"Segmentation returned file: {file}, "
                              f"nuclei out: {len(nuclei_out)}, "
                              f"nuclei in: {len(nuclei_in)}, "

--- a/src/myofinder/main_window.py
+++ b/src/myofinder/main_window.py
@@ -203,10 +203,10 @@ class Main_window(Tk):
         # Some settings should enable the save button when modified
         self.settings.save_overlay.trace_add(
             "write", self._enable_save_button)
-        self.settings.fiber_threshold.trace_add("write",
-                                                self._enable_save_button)
-        self.settings.nuclei_threshold.trace_add("write",
-                                                 self._enable_save_button)
+        self.settings.minimum_fiber_intensity.trace_add(
+            "write", self._enable_save_button)
+        self.settings.minimum_nucleus_intensity.trace_add(
+            "write", self._enable_save_button)
         self.settings.minimum_nuc_diameter.trace_add(
             "write", self._enable_save_button)
 
@@ -802,8 +802,8 @@ class Main_window(Tk):
                 (file,
                  self.settings.nuclei_colour.get(),
                  self.settings.fiber_colour.get(),
-                 self.settings.fiber_threshold.get(),
-                 self.settings.nuclei_threshold.get(),
+                 self.settings.minimum_fiber_intensity.get(),
+                 self.settings.minimum_nucleus_intensity.get(),
                  self.settings.minimum_nuc_diameter.get()))
 
     def _process_thread(self) -> None:
@@ -838,8 +838,8 @@ class Main_window(Tk):
                 # Acquiring the next job in the queue
                 try:
                     job = self._queue.get_nowait()
-                    path, nuclei_color, fiber_color, fiber_threshold, \
-                        nuclei_threshold, minimum_nucleus_diameter = job
+                    (path, nuclei_color, fiber_color, minimum_fiber_intensity,
+                     minimum_nucleus_intensity, minimum_nucleus_diameter) = job
                     self.log(f"Processing thread received job: "
                              f"{', '.join(map(str, job))}")
                 except Empty:
@@ -857,8 +857,8 @@ class Main_window(Tk):
                         self._segmentation(path,
                                            nuclei_color,
                                            fiber_color,
-                                           fiber_threshold,
-                                           nuclei_threshold,
+                                           minimum_fiber_intensity,
+                                           minimum_nucleus_intensity,
                                            minimum_nucleus_diameter)
                     self.log(f"Segmentation returned file: {file}, "
                              f"nuclei out: {len(nuclei_out)}, "

--- a/src/myofinder/main_window.py
+++ b/src/myofinder/main_window.py
@@ -205,7 +205,11 @@ class Main_window(Tk):
             "write", self._enable_save_button)
         self.settings.minimum_fiber_intensity.trace_add(
             "write", self._enable_save_button)
+        self.settings.maximum_fiber_intensity.trace_add(
+            "write", self._enable_save_button)
         self.settings.minimum_nucleus_intensity.trace_add(
+            "write", self._enable_save_button)
+        self.settings.maximum_nucleus_intensity.trace_add(
             "write", self._enable_save_button)
         self.settings.minimum_nuc_diameter.trace_add(
             "write", self._enable_save_button)
@@ -803,7 +807,9 @@ class Main_window(Tk):
                  self.settings.nuclei_colour.get(),
                  self.settings.fiber_colour.get(),
                  self.settings.minimum_fiber_intensity.get(),
+                 self.settings.maximum_fiber_intensity.get(),
                  self.settings.minimum_nucleus_intensity.get(),
+                 self.settings.maximum_nucleus_intensity.get(),
                  self.settings.minimum_nuc_diameter.get()))
 
     def _process_thread(self) -> None:
@@ -839,7 +845,8 @@ class Main_window(Tk):
                 try:
                     job = self._queue.get_nowait()
                     (path, nuclei_color, fiber_color, minimum_fiber_intensity,
-                     minimum_nucleus_intensity, minimum_nucleus_diameter) = job
+                     maximum_fiber_intensity, minimum_nucleus_intensity,
+                     maximum_nucleus_intensity, minimum_nucleus_diameter) = job
                     self.log(f"Processing thread received job: "
                              f"{', '.join(map(str, job))}")
                 except Empty:
@@ -858,7 +865,9 @@ class Main_window(Tk):
                                            nuclei_color,
                                            fiber_color,
                                            minimum_fiber_intensity,
+                                           maximum_fiber_intensity,
                                            minimum_nucleus_intensity,
+                                           maximum_nucleus_intensity,
                                            minimum_nucleus_diameter)
                     self.log(f"Segmentation returned file: {file}, "
                              f"nuclei out: {len(nuclei_out)}, "

--- a/src/myofinder/main_window.py
+++ b/src/myofinder/main_window.py
@@ -140,13 +140,10 @@ class Main_window(Tk):
         """
 
         # Saving the settings
-        settings = {key: value.get() for key, value
-                    in vars(self.settings).items()}
         self.log(f"Settings values: {str(self.settings)}")
-
         settings_file = project_path / 'settings.pickle'
         with open(settings_file, 'wb+') as param_file:
-            dump(settings, param_file, protocol=4)
+            dump(self.settings.get_all(), param_file, protocol=4)
             self.log(f"Saved the settings at: {settings_file}")
 
     def update_master_check(self) -> None:

--- a/src/myofinder/tools/settings_window.py
+++ b/src/myofinder/tools/settings_window.py
@@ -88,47 +88,47 @@ class Settings_window(Toplevel):
             frame, text="Off", variable=self._settings.save_overlay,
             value=0).grid(column=1, row=12, sticky='NW')
 
-        # Slider to adjust the threshold for fiber detection
-        ttk.Label(frame, text='Fiber detection threshold :').grid(
+        # Slider to adjust the minimum intensity for fiber detection
+        ttk.Label(frame, text='Minimum fiber intensity :').grid(
             column=0, row=13, sticky='E', pady=(10, 0), padx=(0, 10))
 
-        fiber_threshold_slider_frame = ttk.Frame(frame)
+        minimum_fiber_intensity_slider_frame = ttk.Frame(frame)
 
-        ttk.Label(fiber_threshold_slider_frame,
-                  textvariable=self._settings.fiber_threshold,
+        ttk.Label(minimum_fiber_intensity_slider_frame,
+                  textvariable=self._settings.minimum_fiber_intensity,
                   width=3). \
             pack(side='left', anchor='w', fill='none', expand=False,
                  padx=(0, 20))
 
-        Scale(fiber_threshold_slider_frame, from_=0, to=100,
+        Scale(minimum_fiber_intensity_slider_frame, from_=0, to=100,
               orient="horizontal",
-              variable=self._settings.fiber_threshold, showvalue=False,
+              variable=self._settings.minimum_fiber_intensity, showvalue=False,
               length=150, tickinterval=20). \
             pack(side='left', anchor='w', fill='none', expand=False)
 
-        fiber_threshold_slider_frame.grid(column=1, row=13, sticky='NW',
-                                          pady=(10, 0))
+        minimum_fiber_intensity_slider_frame.grid(column=1, row=13,
+                                                  sticky='NW', pady=(10, 0))
 
-        # Slider to adjust the threshold for nuclei detection
-        ttk.Label(frame, text='Nuclei detection threshold :').grid(
+        # Slider to adjust the minimum intensity for nuclei detection
+        ttk.Label(frame, text='Minimum nucleus intensity :').grid(
             column=0, row=14, sticky='E', pady=(10, 0), padx=(0, 10))
 
-        nuclei_threshold_slider_frame = ttk.Frame(frame)
+        minimum_nuclei_intensity_slider_frame = ttk.Frame(frame)
 
-        ttk.Label(nuclei_threshold_slider_frame,
-                  textvariable=self._settings.nuclei_threshold,
+        ttk.Label(minimum_nuclei_intensity_slider_frame,
+                  textvariable=self._settings.minimum_nucleus_intensity,
                   width=3). \
             pack(side='left', anchor='w', fill='none', expand=False,
                  padx=(0, 20))
 
-        Scale(nuclei_threshold_slider_frame, from_=0, to=160,
+        Scale(minimum_nuclei_intensity_slider_frame, from_=0, to=160,
               orient="horizontal",
-              variable=self._settings.nuclei_threshold, showvalue=False,
-              length=150, tickinterval=40). \
+              variable=self._settings.minimum_nucleus_intensity,
+              showvalue=False, length=150, tickinterval=40). \
             pack(side='left', anchor='w', fill='none', expand=False)
 
-        nuclei_threshold_slider_frame.grid(column=1, row=14, sticky='NW',
-                                           pady=(10, 0))
+        minimum_nuclei_intensity_slider_frame.grid(column=1, row=14,
+                                                   sticky='NW', pady=(10, 0))
 
         # Slider to adjust the minimum nucleus diameter
         ttk.Label(frame, text='Minimum nucleus diameter (px) :').grid(

--- a/src/myofinder/tools/settings_window.py
+++ b/src/myofinder/tools/settings_window.py
@@ -109,9 +109,30 @@ class Settings_window(Toplevel):
         minimum_fiber_intensity_slider_frame.grid(column=1, row=13,
                                                   sticky='NW', pady=(10, 0))
 
+        # Slider to adjust the maximum intensity for fiber detection
+        ttk.Label(frame, text='Maximum fiber intensity :').grid(
+            column=0, row=14, sticky='E', pady=(10, 0), padx=(0, 10))
+
+        maximum_fiber_intensity_slider_frame = ttk.Frame(frame)
+
+        ttk.Label(maximum_fiber_intensity_slider_frame,
+                  textvariable=self._settings.maximum_fiber_intensity,
+                  width=3). \
+            pack(side='left', anchor='w', fill='none', expand=False,
+                 padx=(0, 20))
+
+        Scale(maximum_fiber_intensity_slider_frame, from_=155, to=255,
+              orient="horizontal",
+              variable=self._settings.maximum_fiber_intensity, showvalue=False,
+              length=150, tickinterval=25). \
+            pack(side='left', anchor='w', fill='none', expand=False)
+
+        maximum_fiber_intensity_slider_frame.grid(column=1, row=14,
+                                                  sticky='NW', pady=(10, 0))
+
         # Slider to adjust the minimum intensity for nuclei detection
         ttk.Label(frame, text='Minimum nucleus intensity :').grid(
-            column=0, row=14, sticky='E', pady=(10, 0), padx=(0, 10))
+            column=0, row=15, sticky='E', pady=(10, 0), padx=(0, 10))
 
         minimum_nuclei_intensity_slider_frame = ttk.Frame(frame)
 
@@ -121,18 +142,39 @@ class Settings_window(Toplevel):
             pack(side='left', anchor='w', fill='none', expand=False,
                  padx=(0, 20))
 
-        Scale(minimum_nuclei_intensity_slider_frame, from_=0, to=160,
+        Scale(minimum_nuclei_intensity_slider_frame, from_=0, to=100,
               orient="horizontal",
               variable=self._settings.minimum_nucleus_intensity,
-              showvalue=False, length=150, tickinterval=40). \
+              showvalue=False, length=150, tickinterval=20). \
             pack(side='left', anchor='w', fill='none', expand=False)
 
-        minimum_nuclei_intensity_slider_frame.grid(column=1, row=14,
+        minimum_nuclei_intensity_slider_frame.grid(column=1, row=15,
+                                                   sticky='NW', pady=(10, 0))
+
+        # Slider to adjust the maximum intensity for nuclei detection
+        ttk.Label(frame, text='Maximum nucleus intensity :').grid(
+            column=0, row=16, sticky='E', pady=(10, 0), padx=(0, 10))
+
+        maximum_nuclei_intensity_slider_frame = ttk.Frame(frame)
+
+        ttk.Label(maximum_nuclei_intensity_slider_frame,
+                  textvariable=self._settings.maximum_nucleus_intensity,
+                  width=3). \
+            pack(side='left', anchor='w', fill='none', expand=False,
+                 padx=(0, 20))
+
+        Scale(maximum_nuclei_intensity_slider_frame, from_=155, to=255,
+              orient="horizontal",
+              variable=self._settings.maximum_nucleus_intensity,
+              showvalue=False, length=150, tickinterval=25). \
+            pack(side='left', anchor='w', fill='none', expand=False)
+
+        maximum_nuclei_intensity_slider_frame.grid(column=1, row=16,
                                                    sticky='NW', pady=(10, 0))
 
         # Slider to adjust the minimum nucleus diameter
         ttk.Label(frame, text='Minimum nucleus diameter (px) :').grid(
-            column=0, row=15, sticky='E', pady=(10, 0), padx=(0, 10))
+            column=0, row=17, sticky='E', pady=(10, 0), padx=(0, 10))
 
         diameter_slider_frame = ttk.Frame(frame)
 
@@ -148,7 +190,7 @@ class Settings_window(Toplevel):
               tickinterval=25). \
             pack(side='left', anchor='w', fill='none', expand=False)
 
-        diameter_slider_frame.grid(column=1, row=15, sticky='NW',
+        diameter_slider_frame.grid(column=1, row=17, sticky='NW',
                                    pady=(10, 0))
 
     def _center(self) -> None:

--- a/src/myofinder/tools/settings_window.py
+++ b/src/myofinder/tools/settings_window.py
@@ -130,26 +130,26 @@ class Settings_window(Toplevel):
         nuclei_threshold_slider_frame.grid(column=1, row=14, sticky='NW',
                                            pady=(10, 0))
 
-        # Slider to adjust the small objects threshold
-        ttk.Label(frame, text='Small Objects Threshold :').grid(
+        # Slider to adjust the minimum nucleus diameter
+        ttk.Label(frame, text='Minimum nucleus diameter (px) :').grid(
             column=0, row=15, sticky='E', pady=(10, 0), padx=(0, 10))
 
-        threshold_slider_frame = ttk.Frame(frame)
+        diameter_slider_frame = ttk.Frame(frame)
 
-        ttk.Label(threshold_slider_frame,
-                  textvariable=self._settings.small_objects_threshold,
+        ttk.Label(diameter_slider_frame,
+                  textvariable=self._settings.minimum_nuc_diameter,
                   width=3). \
             pack(side='left', anchor='w', fill='none', expand=False,
                  padx=(0, 20))
 
-        Scale(threshold_slider_frame, from_=0, to=100,
-              variable=self._settings.small_objects_threshold,
+        Scale(diameter_slider_frame, from_=0, to=100,
+              variable=self._settings.minimum_nuc_diameter,
               orient="horizontal", length=150, showvalue=False,
               tickinterval=25). \
             pack(side='left', anchor='w', fill='none', expand=False)
 
-        threshold_slider_frame.grid(column=1, row=15, sticky='NW',
-                                    pady=(10, 0))
+        diameter_slider_frame.grid(column=1, row=15, sticky='NW',
+                                   pady=(10, 0))
 
     def _center(self) -> None:
         """Centers the popup window on the currently used monitor."""

--- a/src/myofinder/tools/structure_classes.py
+++ b/src/myofinder/tools/structure_classes.py
@@ -8,6 +8,7 @@ from tkinter import StringVar, IntVar, BooleanVar, Checkbutton, PhotoImage, \
     Frame, Event, EventType
 from pathlib import Path
 from platform import system
+import logging
 
 
 @dataclass
@@ -534,15 +535,31 @@ class Settings:
     show_fibers: BooleanVar = field(
         default_factory=partial(BooleanVar, value=False, name='show_fibers'))
 
+    _logger: Optional[logging.Logger] = None
+
+    def __post_init__(self) -> None:
+        """This method defines a logger for this class to be able to log
+        messages."""
+
+        self._logger = logging.getLogger("MyoFInDer.FilesTable")
+
     def update(self, settings: Dict[str, Any]) -> None:
-        """Updates the values of the settings based on the provided
-        dictionary."""
+        """Updates the values of the settings based on the provided dictionary.
+
+        If a key is provided that is not a valid setting, ignores it and
+        displays a warning.
+        """
 
         for key, value in settings.items():
-            getattr(self, key).set(value)
+            try:
+                getattr(self, key).set(value)
+            except AttributeError:
+                self._logger.log(logging.WARNING, f"The {key} setting is not "
+                                                  f"supported, ignoring it !")
 
     def __str__(self) -> str:
-        """"""
+        """Nice string representation of the current settings and their values,
+        used for logging."""
 
         settings = (self.fiber_colour, self.nuclei_colour,
                     self.save_overlay, self.fiber_threshold,

--- a/src/myofinder/tools/structure_classes.py
+++ b/src/myofinder/tools/structure_classes.py
@@ -518,10 +518,12 @@ class Settings:
         default_factory=partial(StringVar, value="blue", name='nuclei_colour'))
     save_overlay: BooleanVar = field(
         default_factory=partial(BooleanVar, value=False, name='save_overlay'))
-    fiber_threshold: IntVar = field(
-        default_factory=partial(IntVar, value=25, name='fiber_threshold'))
-    nuclei_threshold: IntVar = field(
-        default_factory=partial(IntVar, value=25, name='nuclei_threshold'))
+    minimum_fiber_intensity: IntVar = field(
+        default_factory=partial(IntVar, value=25,
+                                name='minimum_fiber_intensity'))
+    minimum_nucleus_intensity: IntVar = field(
+        default_factory=partial(IntVar, value=25,
+                                name='minimum_nucleus_intensity'))
     minimum_nuc_diameter: IntVar = field(
         default_factory=partial(IntVar, value=20, name='minimum_diameter'))
     blue_channel_bool: BooleanVar = field(
@@ -549,8 +551,8 @@ class Settings:
         return {'fiber_colour': self.fiber_colour.get(),
                 'nuclei_colour': self.nuclei_colour.get(),
                 'save_overlay': self.save_overlay.get(),
-                'fiber_threshold': self.fiber_threshold.get(),
-                'nuclei_threshold': self.nuclei_threshold.get(),
+                'minimum_fiber_intensity': self.minimum_fiber_intensity.get(),
+                'minimum_nucleus_intensity': self.minimum_nucleus_intensity.get(),
                 'minimum_nuc_diameter': self.minimum_nuc_diameter.get(),
                 'blue_channel_bool': self.blue_channel_bool.get(),
                 'green_channel_bool': self.green_channel_bool.get(),

--- a/src/myofinder/tools/structure_classes.py
+++ b/src/myofinder/tools/structure_classes.py
@@ -522,8 +522,8 @@ class Settings:
         default_factory=partial(IntVar, value=25, name='fiber_threshold'))
     nuclei_threshold: IntVar = field(
         default_factory=partial(IntVar, value=25, name='nuclei_threshold'))
-    small_objects_threshold: IntVar = field(
-        default_factory=partial(IntVar, value=20, name='small_objects'))
+    minimum_nuc_diameter: IntVar = field(
+        default_factory=partial(IntVar, value=20, name='minimum_diameter'))
     blue_channel_bool: BooleanVar = field(
         default_factory=partial(BooleanVar, value=True, name='blue_channel'))
     green_channel_bool: BooleanVar = field(

--- a/src/myofinder/tools/structure_classes.py
+++ b/src/myofinder/tools/structure_classes.py
@@ -543,6 +543,21 @@ class Settings:
 
         self._logger = logging.getLogger("MyoFInDer.FilesTable")
 
+    def get_all(self) -> Dict[str, Any]:
+        """Returns a dict containing all the settings and their values."""
+
+        return {'fiber_colour': self.fiber_colour.get(),
+                'nuclei_colour': self.nuclei_colour.get(),
+                'save_overlay': self.save_overlay.get(),
+                'fiber_threshold': self.fiber_threshold.get(),
+                'nuclei_threshold': self.nuclei_threshold.get(),
+                'minimum_nuc_diameter': self.minimum_nuc_diameter.get(),
+                'blue_channel_bool': self.blue_channel_bool.get(),
+                'green_channel_bool': self.green_channel_bool.get(),
+                'red_channel_bool': self.red_channel_bool.get(),
+                'show_nuclei': self.show_nuclei.get(),
+                'show_fibers': self.show_fibers.get()}
+
     def update(self, settings: Dict[str, Any]) -> None:
         """Updates the values of the settings based on the provided dictionary.
 
@@ -561,10 +576,5 @@ class Settings:
         """Nice string representation of the current settings and their values,
         used for logging."""
 
-        settings = (self.fiber_colour, self.nuclei_colour,
-                    self.save_overlay, self.fiber_threshold,
-                    self.nuclei_threshold, self.small_objects_threshold,
-                    self.blue_channel_bool, self.green_channel_bool,
-                    self.red_channel_bool, self.show_nuclei, self.show_fibers)
-
-        return ', '.join(f"{setting}: {setting.get()}" for setting in settings)
+        return ', '.join(f"{setting}: {value}" for setting, value
+                         in self.get_all().items())

--- a/src/myofinder/tools/structure_classes.py
+++ b/src/myofinder/tools/structure_classes.py
@@ -521,9 +521,15 @@ class Settings:
     minimum_fiber_intensity: IntVar = field(
         default_factory=partial(IntVar, value=25,
                                 name='minimum_fiber_intensity'))
+    maximum_fiber_intensity: IntVar = field(
+        default_factory=partial(IntVar, value=255,
+                                name='maximum_fiber_intensity'))
     minimum_nucleus_intensity: IntVar = field(
         default_factory=partial(IntVar, value=25,
                                 name='minimum_nucleus_intensity'))
+    maximum_nucleus_intensity: IntVar = field(
+        default_factory=partial(IntVar, value=255,
+                                name='maximum_nucleus_intensity'))
     minimum_nuc_diameter: IntVar = field(
         default_factory=partial(IntVar, value=20, name='minimum_diameter'))
     blue_channel_bool: BooleanVar = field(
@@ -548,17 +554,20 @@ class Settings:
     def get_all(self) -> Dict[str, Any]:
         """Returns a dict containing all the settings and their values."""
 
-        return {'fiber_colour': self.fiber_colour.get(),
-                'nuclei_colour': self.nuclei_colour.get(),
-                'save_overlay': self.save_overlay.get(),
-                'minimum_fiber_intensity': self.minimum_fiber_intensity.get(),
-                'minimum_nucleus_intensity': self.minimum_nucleus_intensity.get(),
-                'minimum_nuc_diameter': self.minimum_nuc_diameter.get(),
-                'blue_channel_bool': self.blue_channel_bool.get(),
-                'green_channel_bool': self.green_channel_bool.get(),
-                'red_channel_bool': self.red_channel_bool.get(),
-                'show_nuclei': self.show_nuclei.get(),
-                'show_fibers': self.show_fibers.get()}
+        return {
+            'fiber_colour': self.fiber_colour.get(),
+            'nuclei_colour': self.nuclei_colour.get(),
+            'save_overlay': self.save_overlay.get(),
+            'minimum_fiber_intensity': self.minimum_fiber_intensity.get(),
+            'maximum_fiber_intensity': self.maximum_fiber_intensity.get(),
+            'minimum_nucleus_intensity': self.minimum_nucleus_intensity.get(),
+            'maximum_nucleus_intensity': self.maximum_nucleus_intensity.get(),
+            'minimum_nuc_diameter': self.minimum_nuc_diameter.get(),
+            'blue_channel_bool': self.blue_channel_bool.get(),
+            'green_channel_bool': self.green_channel_bool.get(),
+            'red_channel_bool': self.red_channel_bool.get(),
+            'show_nuclei': self.show_nuclei.get(),
+            'show_fibers': self.show_fibers.get()}
 
     def update(self, settings: Dict[str, Any]) -> None:
         """Updates the values of the settings based on the provided dictionary.


### PR DESCRIPTION
As described in #16 and #19, the settings displayed for the user to adjust should be improved in two ways:

* The `Small Objects Threshold ` has a non-linear effect and is therefore hard to tune. Its name is also ambiguous.
* The name of the `Fiber Threshold` and `Nuclei Threshold` settings are ambiguous, and equivalent settings adjusting the maximum intensity for fibers or nuclei to be detected could be a simple yet nice improvement.

This PR addresses these two problems:

* The `Small Objects Threshold` was renamed to `Minimum nucleus diameter (px)`.
* It now drives the minimum equivalent diameter a nucleus must have to be detected. Previously, it was directly driving the minimum area of detected nuclei.
* The `Fiber Threshold` and `Nuclei Threshold` settings were renamed to `Minimum fiber intensity` and `Minimum nucleus intensity`, for more clarity.
* Two new `Maximum fiber intensity` and `Maximum nucleus intensity` settings were added, symmetrical to the `Minimum fiber intensity` and `Minimum nucleus intensity` ones but for maximum intensities.
* A check was added when loading the `settings.pickle` file, so that unrecognized settings are ignored instead of raising an exception.

With this PR, the `settings.pickle` file now becomes forward- and backward-compatible for versions greater than 1.0.6. Unrecognized settings are ignored, and unprovided one are set to default.

Closes #16 
Closes #19