### PR TITLE
Add automated workflows

### DIFF
--- a/.github/workflows/build_github_pages.yml
+++ b/.github/workflows/build_github_pages.yml
@@ -26,3 +26,5 @@ jobs:
           destination: ./docs/_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./docs/_site

--- a/.github/workflows/build_github_pages.yml
+++ b/.github/workflows/build_github_pages.yml
@@ -11,6 +11,10 @@ on:
   # May also be started manually
   workflow_dispatch:
 
+  # Runs automatically every first day of the month
+  schedule:
+    - cron: '0 12 1 * *'
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_github_pages.yml
+++ b/.github/workflows/build_github_pages.yml
@@ -1,0 +1,28 @@
+# Workflow checking if the documentation builds with Jekyll as expected
+# Only used for checking if a pull request can be safely merged
+name: Build GitHub Pages with Jekyll
+
+on:
+  # Runs on pull requests targeting the default branch
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: ["main"]
+
+  # May also be started manually
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./docs/_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -1,0 +1,33 @@
+# Installs the Python dependencies, installs MyoFInDer, and checks that it imports
+name: Python Package
+
+on:
+  # Runs on pull requests targeting the default branch
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: ["main"]
+
+  # May also be started manually
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: python -m pip install --upgrade pip wheel build setuptools
+    - name: Install MyoFInDer
+      run: python -m pip install .
+    - name: Import MyoFInDer
+      run: python -c "import myofinder; print(myofinder.__version__)"

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -10,6 +10,10 @@ on:
   # May also be started manually
   workflow_dispatch:
 
+  # Runs automatically every first day of the month
+  schedule:
+    - cron: '0 12 1 * *'
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -12,16 +12,17 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
In an effort to detect bugs as early as possible, this PR adds two workflows that will run on each pull request to the main branch, and every 1st day of the month.
The first workflow checks if the GitHub pages documentation builds as expected. The second installs MyoFInDer on Linux, Windows, and macOS, with each of the supported Python versions, and checks if the module installs and imports correctly.

In the future, more workflows will be added to automatically build the Windows installer, check if it installs, and perform actual tests on MyoFInDer itself.