### PR TITLE
Automate Windows installer build

### DIFF
--- a/.github/workflows/build_github_pages.yml
+++ b/.github/workflows/build_github_pages.yml
@@ -16,6 +16,7 @@ on:
     - cron: '0 12 1 * *'
 
 jobs:
+  # Builds the GitHub pages and uploads the html files
   build-github-pages:
     runs-on: ubuntu-latest
     steps:
@@ -23,12 +24,16 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v4
-      - name: Build with Jekyll
+      - name: Build With Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
           source: ./docs
           destination: ./docs/_site
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+      # Upload only if started manually
+      - name: Upload Artifact
+        if: contains(fromJSON('["workflow_dispatch"]'), github.event_name)
+        uses: actions/upload-pages-artifact@v3
         with:
+          name: docs_folder
           path: ./docs/_site
+          if-no-files-found: error

--- a/.github/workflows/build_github_pages.yml
+++ b/.github/workflows/build_github_pages.yml
@@ -16,7 +16,7 @@ on:
     - cron: '0 12 1 * *'
 
 jobs:
-  build:
+  build-github-pages:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/build_windows_installer.yml
+++ b/.github/workflows/build_windows_installer.yml
@@ -1,0 +1,70 @@
+# Workflow building the Windows Installer file
+name: Build Windows Installer
+
+on:
+  # Runs on pushes on the default branch
+  push:
+    branches: ["main"]
+
+  # Runs on pull requests targeting the default branch
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: ["main"]
+
+  # Runs automatically every first day of the month
+  schedule:
+    - cron: '0 12 1 * *'
+
+  # May also be started manually
+  workflow_dispatch:
+
+jobs:
+  # Builds the Windows installer, tests it, and uploads it
+  build-windows-installer:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      # Generates the .msi file using Advanced Installer
+      - name: Generate MSI
+        uses: caphyon/advinst-github-action@v1.1
+        with:
+          advinst-version: '20.9.1'
+          advinst-enable-automation: 'true'
+          aip-path: ${{ github.workspace }}\src\windows_installer\config.aip
+          aip-build-name: DefaultBuild
+          aip-package-name: myofinder.msi
+          aip-output-dir:  ${{ github.workspace }}\setup
+      # For some reason the installation directory needs to be manually created
+      - name: Create installation folder
+        shell: pwsh
+        run: mkdir "$env:localappdata\MyoFInDer"
+      # Execute the .msi installer to check that it operates as expected
+      # Also, record the logs to a log file
+      - name: Run Installer
+        shell: pwsh
+        run: If ((Start-Process msiexec -Wait -PassThru -ArgumentList "/I",
+             "${{ github.workspace }}\setup\myofinder.msi", 
+             "/qn",
+             "/l*vx",
+             "${{ github.workspace }}\setup\log.txt").ExitCode -ne 0)
+             {exit 1} else
+             {Write-Output "::notice ::{MSI Installation succeeded}"}
+      # If the workflow is manually started, show some debug information
+      - name: Show Debug Info
+        if: contains(fromJSON('["workflow_dispatch"]'), github.event_name)
+        run: type ${{ github.workspace }}\setup\log.txt
+      # Run the startup script installed by the .msi installer
+      # Currently disabled, waiting for some features to be pushed
+      - name: Run Startup Script
+        if: ${{ false }}
+        shell: cmd
+        run:  '%localappdata%\MyoFInDer\start_myofinder.bat'
+      # If the workflow is started manually or by a push, upload the .msi installer
+      - name: Upload artifact
+        if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
+        uses: actions/upload-artifact@v3
+        with:
+          name: myofinder.msi
+          path: ${{ github.workspace }}\setup\myofinder.msi
+          if-no-files-found: error

--- a/.github/workflows/build_windows_installer.yml
+++ b/.github/workflows/build_windows_installer.yml
@@ -36,7 +36,7 @@ jobs:
           aip-package-name: myofinder.msi
           aip-output-dir:  ${{ github.workspace }}\setup
       # For some reason the installation directory needs to be manually created
-      - name: Create installation folder
+      - name: Create Installation Folder
         shell: pwsh
         run: mkdir "$env:localappdata\MyoFInDer"
       # Execute the .msi installer to check that it operates as expected
@@ -61,7 +61,7 @@ jobs:
         shell: cmd
         run:  '%localappdata%\MyoFInDer\start_myofinder.bat'
       # If the workflow is started manually or by a push, upload the .msi installer
-      - name: Upload artifact
+      - name: Upload Artifact
         if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install Dependencies
       run: python -m pip install --upgrade pip wheel build setuptools
     - name: Install MyoFInDer
       run: python -m pip install .

--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -1,5 +1,5 @@
 # Installs the Python dependencies, installs MyoFInDer, and checks that it imports
-name: Python Package
+name: Test Python Package
 
 on:
   # Runs on pull requests targeting the default branch
@@ -15,7 +15,7 @@ on:
     - cron: '0 12 1 * *'
 
 jobs:
-  build:
+  test-python-package:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Until now, the Windows installer file ([`myofinder.msi`](https://github.com/TissueEngineeringLab/MyoFInDer/blob/fa4bf83557f2a383ff9a516aa19aa1f91b93aaa7/bin/myofinder.msi)) needed to be manually built and tested on a Windows machine before each new release. With this PR, the build of the Windows installer is automated by a GitHub workflow (ce174751), and the resulting installer file is uploaded as an artifact. This PR also brings minor changes to the existing workflows.

As is, this PR does not yet allow to fully automate the generation of the installer, as a manual step is still required for testing it and pushing it to the repository. This step should be addressed in a later PR. Also, additional changes to the project are required for the installer to be fully tested. They will come in a later PR.