### PR TITLE
Add a `--test` command line option

### DIFF
--- a/docs/usage.markdown
+++ b/docs/usage.markdown
@@ -26,7 +26,7 @@ Index of the Usage page :
    2. [Loading data from an existing project](#32-loading-data-from-an-existing-project)
    3. [Operations on saved projects](#33-operations-on-saved-projects)
 4. [Advanced usage](#4-advanced-usage)
-   1. [Command-line option](#41-command-line-option)
+   1. [Command-line option](#41-command-line-options)
    2. [Retrieving the log messages](#42-retrieving-the-log-messages)
 
 # 1. Starting MyoFInDer
@@ -346,12 +346,14 @@ impact on the behavior of MyoFInDer.
 
 # 4. Advanced usage
 
-## 4.1 Command-line option
+## 4.1 Command-line options
 
-A single command-line option is available when starting MyoFInDer from the
-console. It allows to **disable logging**, by adding the `-n` or `--nolog` 
-option. It disables both the display of log messages in the console, and 
-recording of the log messages to the log file.
+Two command-line options are available when starting MyoFInDer from the
+console. The first one allows to **disable logging**, by adding the `-n` or 
+`--nolog` option. It disables both the display of log messages in the console, 
+and recording of the log messages to the log file. The second option is for
+**testing only**. It will initialize the interface in a normal way, but close 
+it right away. This behavior is enabled by passing the `-t` or `--test` option.
 
 ## 4.2 Retrieving the log messages
 

--- a/src/myofinder/__main__.py
+++ b/src/myofinder/__main__.py
@@ -26,10 +26,15 @@ def main():
     parser.add_argument('-n', '--nolog', action='store_false',
                         help="If provided, the log messages won't be displayed"
                              " and recorded. Otherwise, they are by default.")
+    parser.add_argument('-t', '--test', action='store_true',
+                        help="If provided, the main window is created but its "
+                             "main loop is never started and the window is "
+                             "destroyed as soon as it is initialized.")
     args = parser.parse_args()
 
-    # Retrieving the command-line argument
-    log = args.nolog
+    # Retrieving the command-line arguments
+    log: bool = args.nolog
+    test: bool = args.test
 
     # Setting the path to the application folder
     if system() in ('Linux', 'Darwin'):
@@ -73,7 +78,12 @@ def main():
     try:
         logger.log(logging.INFO, "Launching MyoFInDer")
         window = MainWindow(app_folder)
-        window.mainloop()
+        # Normal operation mode, start the mainloop
+        if not test:
+            window.mainloop()
+        # Test mode, destroy the main window right away
+        else:
+            window.safe_destroy()
         logger.log(logging.INFO, "MyoFInDer terminated gracefully")
 
     # Displaying the exception and waiting for the user to close the console


### PR DESCRIPTION
So far, the Python installation tests added in #24 only import MyoFInDer, but do not actually test it. Also, the Windows installer build test added in #27 does not execute the final installed `start_myofinder.bat` file. This is because currently, running the module starts the mainloop of the graphical interface, that loops forever.

This PR introduces the `--test` (or `-t`) command line option for MyoFInDer. When provided, the graphical interface initializes as usual, but then closes right at the moment when it would normally start it mainloop. This way, tests do not get stuck in an endless loop and can assert the good initialization of the graphical window. Unlike the bare import, actually starting the module also allows to ensure that the weights of the AI model are downloaded as expected. This PR also updates the documentation for this new feature.

In a later PR, a proper test suite will be added that will replace or complement the `--test` run in automated workflows. This `--test` run is only a step towards a more robust and complete solution.