### PR TITLE
Improve the test workflows

### DIFF
--- a/.github/workflows/build_windows_installer.yml
+++ b/.github/workflows/build_windows_installer.yml
@@ -25,6 +25,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      # Set up Python 3.10
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      # Build the wheel for the latest version
+      - name: Build Wheel
+        run: |
+          python -m venv ${{ github.workspace }}\venv
+          ${{ github.workspace }}\venv\Scripts\python.exe -m pip install --upgrade pip wheel build setuptools
+          ${{ github.workspace }}\venv\Scripts\python.exe -m build ${{ github.workspace }} -o ${{ github.workspace }}\dist
       # Generates the .msi file using Advanced Installer
       - name: Generate MSI
         uses: caphyon/advinst-github-action@v1.1
@@ -54,12 +65,14 @@ jobs:
       - name: Show Debug Info
         if: contains(fromJSON('["workflow_dispatch"]'), github.event_name)
         run: type ${{ github.workspace }}\setup\log.txt
-      # Run the startup script installed by the .msi installer
-      # Currently disabled, waiting for some features to be pushed
+      # Getting the name of the wheel, cannot do it in the Windows shell
+      - name: Get Wheel Name
+        shell: bash
+        run: echo "WHEEL_NAME=$(echo '${{ github.workspace }}\dist\')$(ls '${{ github.workspace }}\dist' | grep \.whl$ | head -n 1)" >> $GITHUB_ENV
+      # Run the startup script installed by the .msi installer in test mode
       - name: Run Startup Script
-        if: ${{ false }}
         shell: cmd
-        run:  '%localappdata%\MyoFInDer\start_myofinder.bat'
+        run: '%localappdata%\MyoFInDer\start_myofinder.bat -t ${{ env.WHEEL_NAME }}'
       # If the workflow is started manually or by a push, upload the .msi installer
       - name: Upload Artifact
         if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)

--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies

--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -20,19 +20,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Run on all the supported Python versions
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+        # Run on all the supported platforms
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
+    # Checkout the repository
     - name: Checkout
       uses: actions/checkout@v4
+    # Set up the correct version of Python
     - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+    # Install the build dependencies
     - name: Install Dependencies
       run: python -m pip install --upgrade pip wheel build setuptools
+    # Install the MyoFInDer Python module
     - name: Install MyoFInDer
       run: python -m pip install .
-    - name: Import MyoFInDer
-      run: python -c "import myofinder; print(myofinder.__version__)"
+    # On Windows, MyoFInDer can run even though there is no graphical environment
+    - name: Run MyoFInDer (Windows)
+      if: runner.os == 'Windows'
+      run: python -m myofinder -t
+    # On macOS and Linux, it is not possible to start the module without a graphical environment
+    - name: Import MyoFInDer (macOS and Linux)
+      if: contains(fromJSON('["macOS", "Linux"]'), runner.os)
+      run: python -c "import myofinder;print(myofinder.__version__)"

--- a/src/windows_installer/start_myofinder.bat
+++ b/src/windows_installer/start_myofinder.bat
@@ -56,7 +56,7 @@ echo Checking if the dependencies are installed
         %base_path%\venv\Scripts\python -m pip install myofinder==1.0.7
     ) else (
         echo Installing the locally built package in test mode
-        %base_path%\venv\Scripts\python -m pip install --no-index -f "%2"
+        %base_path%\venv\Scripts\python -m pip install --no-index -f "%2" myofinder
     )
 )
 

--- a/src/windows_installer/start_myofinder.bat
+++ b/src/windows_installer/start_myofinder.bat
@@ -36,12 +36,28 @@ if exist %base_path%\venv (
 
 echo.
 
+echo Checking if MyoFInDer should run in test mode
+if "%1"=="-t" (
+    set test=true
+    echo Running in test mode
+) else (
+    set test=false
+    echo Running in regular mode
+)
+
+echo.
+
 echo Checking if the dependencies are installed
 %base_path%\venv\Scripts\python -m pip list | findstr "myofinder" >nul 2>&1 && (
     echo The dependencies are installed
 ) || (
     echo The dependencies are not installed, installing them
-    %base_path%\venv\Scripts\python -m pip install myofinder==1.0.7
+    if "%test%"=="false" (
+        %base_path%\venv\Scripts\python -m pip install myofinder==1.0.7
+    ) else (
+        echo Installing the locally built package in test mode
+        %base_path%\venv\Scripts\python -m pip install --no-index -f "%2"
+    )
 )
 
 echo.
@@ -53,17 +69,6 @@ echo Checking that MyoFInDer is correctly installed
     echo Something went wrong during MyoFInDer's installation !
     pause
     exit /b 1
-)
-
-echo.
-
-echo Checking if MyoFInDer should run in test mode
-if "%1"=="-t" (
-    set test=true
-    echo Running in test mode
-) else (
-    set test=false
-    echo Running in regular mode
 )
 
 echo.

--- a/src/windows_installer/start_myofinder.bat
+++ b/src/windows_installer/start_myofinder.bat
@@ -56,7 +56,7 @@ echo Checking if the dependencies are installed
         %base_path%\venv\Scripts\python -m pip install myofinder==1.0.7
     ) else (
         echo Installing the locally built package in test mode
-        %base_path%\venv\Scripts\python -m pip install --no-index -f "%2" myofinder
+        %base_path%\venv\Scripts\python -m pip install "%2"
     )
 )
 

--- a/src/windows_installer/start_myofinder.bat
+++ b/src/windows_installer/start_myofinder.bat
@@ -46,7 +46,7 @@ echo Checking if the dependencies are installed
 
 echo.
 
-echo Checking that MyoFInDer was correctly installed
+echo Checking that MyoFInDer is correctly installed
 %base_path%\venv\Scripts\python -c "import myofinder" && (
     echo MyoFInDer was correctly installed
 ) || (
@@ -57,5 +57,20 @@ echo Checking that MyoFInDer was correctly installed
 
 echo.
 
+echo Checking if MyoFInDer should run in test mode
+if "%1"=="-t" (
+    set test=true
+    echo Running in test mode
+) else (
+    set test=false
+    echo Running in regular mode
+)
+
+echo.
+
 echo Starting MyoFInDer
-%base_path%\venv\Scripts\python -m myofinder
+if "%test%"=="false" (
+    %base_path%\venv\Scripts\python -m myofinder
+) else (
+    %base_path%\venv\Scripts\python -m myofinder -t
+)


### PR DESCRIPTION
In #29, a test mode was added to the module MyoFInDer to make it initialize without fully running. This test mode was however only implemented, but not actually used anywhere.

This PR make use of the test mode in two of the three implemented test workflows. In [`test_python_package.yml`](https://github.com/TissueEngineeringLab/MyoFInDer/blob/b5f492b178dec30d8e191c61ca4ddbb9a4ef5fea/.github/workflows/test_python_package.yml), the tests on Windows now start MyoFInDer in test mode instead of just importing the module. On Linux and macOS, however, this is not possible in absence of a graphical environment. The correct configuration for running tests on these OS without a graphical environment might be added in future works.

In [`build_windows_installer.yml`](https://github.com/TissueEngineeringLab/MyoFInDer/blob/b5f492b178dec30d8e191c61ca4ddbb9a4ef5fea/.github/workflows/build_windows_installer.yml), a wheel of the latest version of MyoFInDer is now built, and installed by the [`start_myofinder.bat`](https://github.com/TissueEngineeringLab/MyoFInDer/blob/b5f492b178dec30d8e191c61ca4ddbb9a4ef5fea/src/windows_installer/start_myofinder.bat) script. The installed version of the module is then started in test mode, on a Windows machine.

The tests conducted in the workflows are still pretty basic. In future works, a more comprehensive test suite should be added and ideally run on all the supported Python versions and platforms.