### PR TITLE
Update the Windows installer config file

### DIFF
--- a/src/windows_installer/LICENSE.rtf
+++ b/src/windows_installer/LICENSE.rtf
@@ -1,0 +1,1550 @@
+{\rtf1\ansi\deff3\adeflang1025
+{\fonttbl{\f0\froman\fprq2\fcharset0 Times New Roman;}{\f1\froman\fprq2\fcharset2 Symbol;}{\f2\fswiss\fprq2\fcharset0 Arial;}{\f3\froman\fprq2\fcharset0 Liberation Serif{\*\falt Times New Roman};}{\f4\fmodern\fprq1\fcharset0 Liberation Mono{\*\falt Courier New};}{\f5\fswiss\fprq2\fcharset0 Liberation Sans{\*\falt Arial};}{\f6\fnil\fprq2\fcharset0 Microsoft YaHei;}{\f7\fmodern\fprq1\fcharset0 NSimSun;}{\f8\fnil\fprq2\fcharset0 Lucida Sans;}{\f9\fswiss\fprq0\fcharset128 Lucida Sans;}}
+{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;}
+{\stylesheet{\s0\snext0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\nowidctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\dbch\af10\langfe2052 Normal;}
+{\s15\sbasedon0\snext16\rtlch\af8\afs28 \ltrch\hich\af5\loch\sb240\sa120\keepn\f5\fs28\dbch\af6 Heading;}
+{\s16\sbasedon0\snext16\loch\sl276\slmult1\sb0\sa140 Body Text;}
+{\s17\sbasedon16\snext17\rtlch\af9 \ltrch\loch\sl276\slmult1\sb0\sa140 List;}
+{\s18\sbasedon0\snext18\rtlch\af9\afs24\ai \ltrch\loch\sb120\sa120\noline\fs24\i Caption;}
+{\s19\sbasedon0\snext19\rtlch\af9 \ltrch\loch\noline Index;}
+{\s20\sbasedon0\snext20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7 Preformatted Text;}
+}{\*\generator LibreOffice/7.6.4.1$Windows_X86_64 LibreOffice_project/e19e193f88cd6c0525a17fb7a176ed8e6a3e2aa1}{\info{\creatim\yr0\mo0\dy0\hr0\min0}{\revtim\yr0\mo0\dy0\hr0\min0}{\printim\yr0\mo0\dy0\hr0\min0}}{\*\userprops}\deftab709
+\hyphauto1\viewscale100\formshade\nobrkwrptbl\paperh15840\paperw12240\margl1134\margr1134\margt1134\margb1134\sectd\sbknone\sftnnar\saftnnrlc\sectunlocked1\pgwsxn12240\pghsxn15840\marglsxn1134\margrsxn1134\margtsxn1134\margbsxn1134\ftnbj\ftnstart1\ftnrstcont\ftnnar\aenddoc\aftnrstcont\aftnstart1\aftnnrlc
+{\*\ftnsep\chftnsep}\pgndec\pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+                    }{\loch
+GNU GENERAL PUBLIC LICENSE}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+                       }{\loch
+Version 3, 29 June 2007}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+ }{\loch
+Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+ }{\loch
+Everyone is permitted to copy and distribute verbatim copies}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+ }{\loch
+of this license document, but changing it is not allowed.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+                            }{\loch
+Preamble}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+The GNU General Public License is a free, copyleft license for}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+software and other kinds of works.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+The licenses for most software and other practical works are designed}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+to take away your freedom to share and change the works.  By contrast,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+the GNU General Public License is intended to guarantee your freedom to}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+share and change all versions of a program--to make sure it remains free}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+software for all its users.  We, the Free Software Foundation, use the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+GNU General Public License for most of our software; it applies also to}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+any other work released this way by its authors.  You can apply it to}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+your programs, too.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+When we speak of free software, we are referring to freedom, not}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+price.  Our General Public Licenses are designed to make sure that you}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+have the freedom to distribute copies of free software (and charge for}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+them if you wish), that you receive source code or can get it if you}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+want it, that you can change the software or use pieces of it in new}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+free programs, and that you know you can do these things.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+To protect your rights, we need to prevent others from denying you}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+these rights or asking you to surrender the rights.  Therefore, you have}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+certain responsibilities if you distribute copies of the software, or if}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+you modify it: responsibilities to respect the freedom of others.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+For example, if you distribute copies of such a program, whether}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+gratis or for a fee, you must pass on to the recipients the same}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+freedoms that you received.  You must make sure that they, too, receive}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+or can get the source code.  And you must show them these terms so they}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+know their rights.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+Developers that use the GNU GPL protect your rights with two steps:}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+(1) assert copyright on the software, and (2) offer you this License}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+giving you legal permission to copy, distribute and/or modify it.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+For the developers' and authors' protection, the GPL clearly explains}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+that there is no warranty for this free software.  For both users' and}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+authors' sake, the GPL requires that modified versions be marked as}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+changed, so that their problems will not be attributed erroneously to}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+authors of previous versions.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+Some devices are designed to deny users access to install or run}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+modified versions of the software inside them, although the manufacturer}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+can do so.  This is fundamentally incompatible with the aim of}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+protecting users' freedom to change the software.  The systematic}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+pattern of such abuse occurs in the area of products for individuals to}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+use, which is precisely where it is most unacceptable.  Therefore, we}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+have designed this version of the GPL to prohibit the practice for those}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+products.  If such problems arise substantially in other domains, we}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+stand ready to extend this provision to those domains in future versions}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+of the GPL, as needed to protect the freedom of users.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+Finally, every program is threatened constantly by software patents.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+States should not allow patents to restrict development and use of}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+software on general-purpose computers, but in those that do, we wish to}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+avoid the special danger that patents applied to a free program could}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+make it effectively proprietary.  To prevent this, the GPL assures that}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+patents cannot be used to render the program non-free.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+The precise terms and conditions for copying, distribution and}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+modification follow.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+                       }{\loch
+TERMS AND CONDITIONS}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+0. Definitions.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+"This License" refers to version 3 of the GNU General Public License.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+"Copyright" also means copyright-like laws that apply to other kinds of}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+works, such as semiconductor masks.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+"The Program" refers to any copyrightable work licensed under this}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+License.  Each licensee is addressed as "you".  "Licensees" and}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+"recipients" may be individuals or organizations.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+To "modify" a work means to copy from or adapt all or part of the work}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+in a fashion requiring copyright permission, other than the making of an}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+exact copy.  The resulting work is called a "modified version" of the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+earlier work or a work "based on" the earlier work.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+A "covered work" means either the unmodified Program or a work based}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+on the Program.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+To "propagate" a work means to do anything with it that, without}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+permission, would make you directly or secondarily liable for}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+infringement under applicable copyright law, except executing it on a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+computer or modifying a private copy.  Propagation includes copying,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+distribution (with or without modification), making available to the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+public, and in some countries other activities as well.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+To "convey" a work means any kind of propagation that enables other}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+parties to make or receive copies.  Mere interaction with a user through}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+a computer network, with no transfer of a copy, is not conveying.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+An interactive user interface displays "Appropriate Legal Notices"}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+to the extent that it includes a convenient and prominently visible}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+feature that (1) displays an appropriate copyright notice, and (2)}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+tells the user that there is no warranty for the work (except to the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+extent that warranties are provided), that licensees may convey the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+work under this License, and how to view a copy of this License.  If}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+the interface presents a list of user commands or options, such as a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+menu, a prominent item in the list meets this criterion.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+1. Source Code.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+The "source code" for a work means the preferred form of the work}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+for making modifications to it.  "Object code" means any non-source}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+form of a work.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+A "Standard Interface" means an interface that either is an official}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+standard defined by a recognized standards body, or, in the case of}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+interfaces specified for a particular programming language, one that}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+is widely used among developers working in that language.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+The "System Libraries" of an executable work include anything, other}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+than the work as a whole, that (a) is included in the normal form of}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+packaging a Major Component, but which is not part of that Major}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+Component, and (b) serves only to enable use of the work with that}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+Major Component, or to implement a Standard Interface for which an}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+implementation is available to the public in source code form.  A}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+"Major Component", in this context, means a major essential component}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+(kernel, window system, and so on) of the specific operating system}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+(if any) on which the executable work runs, or a compiler used to}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+produce the work, or an object code interpreter used to run it.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+The "Corresponding Source" for a work in object code form means all}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+the source code needed to generate, install, and (for an executable}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+work) run the object code and to modify the work, including scripts to}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+control those activities.  However, it does not include the work's}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+System Libraries, or general-purpose tools or generally available free}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+programs which are used unmodified in performing those activities but}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+which are not part of the work.  For example, Corresponding Source}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+includes interface definition files associated with source files for}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+the work, and the source code for shared libraries and dynamically}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+linked subprograms that the work is specifically designed to require,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+such as by intimate data communication or control flow between those}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+subprograms and other parts of the work.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+The Corresponding Source need not include anything that users}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+can regenerate automatically from other parts of the Corresponding}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+Source.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+The Corresponding Source for a work in source code form is that}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+same work.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+2. Basic Permissions.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+All rights granted under this License are granted for the term of}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+copyright on the Program, and are irrevocable provided the stated}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+conditions are met.  This License explicitly affirms your unlimited}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+permission to run the unmodified Program.  The output from running a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+covered work is covered by this License only if the output, given its}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+content, constitutes a covered work.  This License acknowledges your}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+rights of fair use or other equivalent, as provided by copyright law.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+You may make, run and propagate covered works that you do not}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+convey, without conditions so long as your license otherwise remains}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+in force.  You may convey covered works to others for the sole purpose}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+of having them make modifications exclusively for you, or provide you}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+with facilities for running those works, provided that you comply with}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+the terms of this License in conveying all material for which you do}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+not control copyright.  Those thus making or running the covered works}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+for you must do so exclusively on your behalf, under your direction}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+and control, on terms that prohibit them from making any copies of}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+your copyrighted material outside their relationship with you.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+Conveying under any other circumstances is permitted solely under}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+the conditions stated below.  Sublicensing is not allowed; section 10}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+makes it unnecessary.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+No covered work shall be deemed part of an effective technological}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+measure under any applicable law fulfilling obligations under article}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+11 of the WIPO copyright treaty adopted on 20 December 1996, or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+similar laws prohibiting or restricting circumvention of such}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+measures.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+When you convey a covered work, you waive any legal power to forbid}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+circumvention of technological measures to the extent such circumvention}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+is effected by exercising rights under this License with respect to}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+the covered work, and you disclaim any intention to limit operation or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+modification of the work as a means of enforcing, against the work's}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+users, your or third parties' legal rights to forbid circumvention of}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+technological measures.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+4. Conveying Verbatim Copies.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+You may convey verbatim copies of the Program's source code as you}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+receive it, in any medium, provided that you conspicuously and}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+appropriately publish on each copy an appropriate copyright notice;}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+keep intact all notices stating that this License and any}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+non-permissive terms added in accord with section 7 apply to the code;}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+keep intact all notices of the absence of any warranty; and give all}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+recipients a copy of this License along with the Program.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+You may charge any price or no price for each copy that you convey,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+and you may offer support or warranty protection for a fee.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+5. Conveying Modified Source Versions.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+You may convey a work based on the Program, or the modifications to}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+produce it from the Program, in the form of source code under the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+terms of section 4, provided that you also meet all of these conditions:}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+a) The work must carry prominent notices stating that you modified}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+it, and giving a relevant date.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+b) The work must carry prominent notices stating that it is}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+released under this License and any conditions added under section}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+7.  This requirement modifies the requirement in section 4 to}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+"keep intact all notices".}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+c) You must license the entire work, as a whole, under this}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+License to anyone who comes into possession of a copy.  This}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+License will therefore apply, along with any applicable section 7}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+additional terms, to the whole of the work, and all its parts,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+regardless of how they are packaged.  This License gives no}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+permission to license the work in any other way, but it does not}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+invalidate such permission if you have separately received it.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+d) If the work has interactive user interfaces, each must display}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+Appropriate Legal Notices; however, if the Program has interactive}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+interfaces that do not display Appropriate Legal Notices, your}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+work need not make them do so.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+A compilation of a covered work with other separate and independent}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+works, which are not by their nature extensions of the covered work,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+and which are not combined with it such as to form a larger program,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+in or on a volume of a storage or distribution medium, is called an}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+"aggregate" if the compilation and its resulting copyright are not}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+used to limit the access or legal rights of the compilation's users}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+beyond what the individual works permit.  Inclusion of a covered work}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+in an aggregate does not cause this License to apply to the other}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+parts of the aggregate.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+6. Conveying Non-Source Forms.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+You may convey a covered work in object code form under the terms}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+of sections 4 and 5, provided that you also convey the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+machine-readable Corresponding Source under the terms of this License,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+in one of these ways:}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+a) Convey the object code in, or embodied in, a physical product}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+(including a physical distribution medium), accompanied by the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+Corresponding Source fixed on a durable physical medium}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+customarily used for software interchange.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+b) Convey the object code in, or embodied in, a physical product}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+(including a physical distribution medium), accompanied by a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+written offer, valid for at least three years and valid for as}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+long as you offer spare parts or customer support for that product}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+model, to give anyone who possesses the object code either (1) a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+copy of the Corresponding Source for all the software in the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+product that is covered by this License, on a durable physical}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+medium customarily used for software interchange, for a price no}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+more than your reasonable cost of physically performing this}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+conveying of source, or (2) access to copy the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+Corresponding Source from a network server at no charge.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+c) Convey individual copies of the object code with a copy of the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+written offer to provide the Corresponding Source.  This}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+alternative is allowed only occasionally and noncommercially, and}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+only if you received the object code with such an offer, in accord}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+with subsection 6b.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+d) Convey the object code by offering access from a designated}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+place (gratis or for a charge), and offer equivalent access to the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+Corresponding Source in the same way through the same place at no}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+further charge.  You need not require recipients to copy the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+Corresponding Source along with the object code.  If the place to}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+copy the object code is a network server, the Corresponding Source}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+may be on a different server (operated by you or a third party)}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+that supports equivalent copying facilities, provided you maintain}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+clear directions next to the object code saying where to find the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+Corresponding Source.  Regardless of what server hosts the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+Corresponding Source, you remain obligated to ensure that it is}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+available for as long as needed to satisfy these requirements.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+e) Convey the object code using peer-to-peer transmission, provided}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+you inform other peers where the object code and Corresponding}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+Source of the work are being offered to the general public at no}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+charge under subsection 6d.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+A separable portion of the object code, whose source code is excluded}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+from the Corresponding Source as a System Library, need not be}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+included in conveying the object code work.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+A "User Product" is either (1) a "consumer product", which means any}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+tangible personal property which is normally used for personal, family,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+or household purposes, or (2) anything designed or sold for incorporation}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+into a dwelling.  In determining whether a product is a consumer product,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+doubtful cases shall be resolved in favor of coverage.  For a particular}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+product received by a particular user, "normally used" refers to a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+typical or common use of that class of product, regardless of the status}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+of the particular user or of the way in which the particular user}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+actually uses, or expects or is expected to use, the product.  A product}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+is a consumer product regardless of whether the product has substantial}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+commercial, industrial or non-consumer uses, unless such uses represent}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+the only significant mode of use of the product.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+"Installation Information" for a User Product means any methods,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+procedures, authorization keys, or other information required to install}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+and execute modified versions of a covered work in that User Product from}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+a modified version of its Corresponding Source.  The information must}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+suffice to ensure that the continued functioning of the modified object}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+code is in no case prevented or interfered with solely because}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+modification has been made.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+If you convey an object code work under this section in, or with, or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+specifically for use in, a User Product, and the conveying occurs as}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+part of a transaction in which the right of possession and use of the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+User Product is transferred to the recipient in perpetuity or for a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+fixed term (regardless of how the transaction is characterized), the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+Corresponding Source conveyed under this section must be accompanied}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+by the Installation Information.  But this requirement does not apply}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+if neither you nor any third party retains the ability to install}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+modified object code on the User Product (for example, the work has}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+been installed in ROM).}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+The requirement to provide Installation Information does not include a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+requirement to continue to provide support service, warranty, or updates}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+for a work that has been modified or installed by the recipient, or for}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+the User Product in which it has been modified or installed.  Access to a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+network may be denied when the modification itself materially and}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+adversely affects the operation of the network or violates the rules and}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+protocols for communication across the network.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+Corresponding Source conveyed, and Installation Information provided,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+in accord with this section must be in a format that is publicly}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+documented (and with an implementation available to the public in}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+source code form), and must require no special password or key for}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+unpacking, reading or copying.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+7. Additional Terms.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+"Additional permissions" are terms that supplement the terms of this}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+License by making exceptions from one or more of its conditions.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+Additional permissions that are applicable to the entire Program shall}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+be treated as though they were included in this License, to the extent}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+that they are valid under applicable law.  If additional permissions}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+apply only to part of the Program, that part may be used separately}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+under those permissions, but the entire Program remains governed by}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+this License without regard to the additional permissions.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+When you convey a copy of a covered work, you may at your option}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+remove any additional permissions from that copy, or from any part of}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+it.  (Additional permissions may be written to require their own}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+removal in certain cases when you modify the work.)  You may place}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+additional permissions on material, added by you to a covered work,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+for which you have or can give appropriate copyright permission.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+Notwithstanding any other provision of this License, for material you}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+add to a covered work, you may (if authorized by the copyright holders of}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+that material) supplement the terms of this License with terms:}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+a) Disclaiming warranty or limiting liability differently from the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+terms of sections 15 and 16 of this License; or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+b) Requiring preservation of specified reasonable legal notices or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+author attributions in that material or in the Appropriate Legal}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+Notices displayed by works containing it; or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+c) Prohibiting misrepresentation of the origin of that material, or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+requiring that modified versions of such material be marked in}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+reasonable ways as different from the original version; or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+d) Limiting the use for publicity purposes of names of licensors or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+authors of the material; or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+e) Declining to grant rights under trademark law for use of some}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+trade names, trademarks, or service marks; or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+f) Requiring indemnification of licensors and authors of that}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+material by anyone who conveys the material (or modified versions of}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+it) with contractual assumptions of liability to the recipient, for}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+any liability that these contractual assumptions directly impose on}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+those licensors and authors.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+All other non-permissive additional terms are considered "further}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+restrictions" within the meaning of section 10.  If the Program as you}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+received it, or any part of it, contains a notice stating that it is}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+governed by this License along with a term that is a further}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+restriction, you may remove that term.  If a license document contains}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+a further restriction but permits relicensing or conveying under this}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+License, you may add to a covered work material governed by the terms}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+of that license document, provided that the further restriction does}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+not survive such relicensing or conveying.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+If you add terms to a covered work in accord with this section, you}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+must place, in the relevant source files, a statement of the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+additional terms that apply to those files, or a notice indicating}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+where to find the applicable terms.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+Additional terms, permissive or non-permissive, may be stated in the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+form of a separately written license, or stated as exceptions;}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+the above requirements apply either way.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+8. Termination.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+You may not propagate or modify a covered work except as expressly}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+provided under this License.  Any attempt otherwise to propagate or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+modify it is void, and will automatically terminate your rights under}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+this License (including any patent licenses granted under the third}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+paragraph of section 11).}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+However, if you cease all violation of this License, then your}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+license from a particular copyright holder is reinstated (a)}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+provisionally, unless and until the copyright holder explicitly and}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+finally terminates your license, and (b) permanently, if the copyright}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+holder fails to notify you of the violation by some reasonable means}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+prior to 60 days after the cessation.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+Moreover, your license from a particular copyright holder is}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+reinstated permanently if the copyright holder notifies you of the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+violation by some reasonable means, this is the first time you have}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+received notice of violation of this License (for any work) from that}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+copyright holder, and you cure the violation prior to 30 days after}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+your receipt of the notice.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+Termination of your rights under this section does not terminate the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+licenses of parties who have received copies or rights from you under}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+this License.  If your rights have been terminated and not permanently}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+reinstated, you do not qualify to receive new licenses for the same}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+material under section 10.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+9. Acceptance Not Required for Having Copies.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+You are not required to accept this License in order to receive or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+run a copy of the Program.  Ancillary propagation of a covered work}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+occurring solely as a consequence of using peer-to-peer transmission}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+to receive a copy likewise does not require acceptance.  However,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+nothing other than this License grants you permission to propagate or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+modify any covered work.  These actions infringe copyright if you do}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+not accept this License.  Therefore, by modifying or propagating a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+covered work, you indicate your acceptance of this License to do so.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+10. Automatic Licensing of Downstream Recipients.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+Each time you convey a covered work, the recipient automatically}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+receives a license from the original licensors, to run, modify and}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+propagate that work, subject to this License.  You are not responsible}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+for enforcing compliance by third parties with this License.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+An "entity transaction" is a transaction transferring control of an}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+organization, or substantially all assets of one, or subdividing an}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+organization, or merging organizations.  If propagation of a covered}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+work results from an entity transaction, each party to that}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+transaction who receives a copy of the work also receives whatever}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+licenses to the work the party's predecessor in interest had or could}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+give under the previous paragraph, plus a right to possession of the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+Corresponding Source of the work from the predecessor in interest, if}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+the predecessor has it or can get it with reasonable efforts.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+You may not impose any further restrictions on the exercise of the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+rights granted or affirmed under this License.  For example, you may}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+not impose a license fee, royalty, or other charge for exercise of}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+rights granted under this License, and you may not initiate litigation}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+(including a cross-claim or counterclaim in a lawsuit) alleging that}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+any patent claim is infringed by making, using, selling, offering for}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+sale, or importing the Program or any portion of it.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+11. Patents.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+A "contributor" is a copyright holder who authorizes use under this}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+License of the Program or a work on which the Program is based.  The}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+work thus licensed is called the contributor's "contributor version".}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+A contributor's "essential patent claims" are all patent claims}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+owned or controlled by the contributor, whether already acquired or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+hereafter acquired, that would be infringed by some manner, permitted}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+by this License, of making, using, or selling its contributor version,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+but do not include claims that would be infringed only as a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+consequence of further modification of the contributor version.  For}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+purposes of this definition, "control" includes the right to grant}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+patent sublicenses in a manner consistent with the requirements of}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+this License.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+Each contributor grants you a non-exclusive, worldwide, royalty-free}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+patent license under the contributor's essential patent claims, to}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+make, use, sell, offer for sale, import and otherwise run, modify and}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+propagate the contents of its contributor version.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+In the following three paragraphs, a "patent license" is any express}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+agreement or commitment, however denominated, not to enforce a patent}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+(such as an express permission to practice a patent or covenant not to}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+sue for patent infringement).  To "grant" such a patent license to a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+party means to make such an agreement or commitment not to enforce a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+patent against the party.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+If you convey a covered work, knowingly relying on a patent license,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+and the Corresponding Source of the work is not available for anyone}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+to copy, free of charge and under the terms of this License, through a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+publicly available network server or other readily accessible means,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+then you must either (1) cause the Corresponding Source to be so}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+available, or (2) arrange to deprive yourself of the benefit of the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+patent license for this particular work, or (3) arrange, in a manner}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+consistent with the requirements of this License, to extend the patent}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+license to downstream recipients.  "Knowingly relying" means you have}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+actual knowledge that, but for the patent license, your conveying the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+covered work in a country, or your recipient's use of the covered work}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+in a country, would infringe one or more identifiable patents in that}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+country that you have reason to believe are valid.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+If, pursuant to or in connection with a single transaction or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+arrangement, you convey, or propagate by procuring conveyance of, a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+covered work, and grant a patent license to some of the parties}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+receiving the covered work authorizing them to use, propagate, modify}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+or convey a specific copy of the covered work, then the patent license}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+you grant is automatically extended to all recipients of the covered}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+work and works based on it.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+A patent license is "discriminatory" if it does not include within}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+the scope of its coverage, prohibits the exercise of, or is}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+conditioned on the non-exercise of one or more of the rights that are}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+specifically granted under this License.  You may not convey a covered}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+work if you are a party to an arrangement with a third party that is}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+in the business of distributing software, under which you make payment}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+to the third party based on the extent of your activity of conveying}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+the work, and under which the third party grants, to any of the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+parties who would receive the covered work from you, a discriminatory}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+patent license (a) in connection with copies of the covered work}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+conveyed by you (or copies made from those copies), or (b) primarily}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+for and in connection with specific products or compilations that}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+contain the covered work, unless you entered into that arrangement,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+or that patent license was granted, prior to 28 March 2007.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+Nothing in this License shall be construed as excluding or limiting}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+any implied license or other defenses to infringement that may}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+otherwise be available to you under applicable patent law.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+12. No Surrender of Others' Freedom.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+If conditions are imposed on you (whether by court order, agreement or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+otherwise) that contradict the conditions of this License, they do not}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+excuse you from the conditions of this License.  If you cannot convey a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+covered work so as to satisfy simultaneously your obligations under this}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+License and any other pertinent obligations, then as a consequence you may}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+not convey it at all.  For example, if you agree to terms that obligate you}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+to collect a royalty for further conveying from those to whom you convey}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+the Program, the only way you could satisfy both those terms and this}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+License would be to refrain entirely from conveying the Program.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+13. Use with the GNU Affero General Public License.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+Notwithstanding any other provision of this License, you have}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+permission to link or combine any covered work with a work licensed}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+under version 3 of the GNU Affero General Public License into a single}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+combined work, and to convey the resulting work.  The terms of this}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+License will continue to apply to the part which is the covered work,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+but the special requirements of the GNU Affero General Public License,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+section 13, concerning interaction through a network will apply to the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+combination as such.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+14. Revised Versions of this License.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+The Free Software Foundation may publish revised and/or new versions of}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+the GNU General Public License from time to time.  Such new versions will}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+be similar in spirit to the present version, but may differ in detail to}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+address new problems or concerns.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+Each version is given a distinguishing version number.  If the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+Program specifies that a certain numbered version of the GNU General}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+Public License "or any later version" applies to it, you have the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+option of following the terms and conditions either of that numbered}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+version or of any later version published by the Free Software}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+Foundation.  If the Program does not specify a version number of the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+GNU General Public License, you may choose any version ever published}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+by the Free Software Foundation.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+If the Program specifies that a proxy can decide which future}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+versions of the GNU General Public License can be used, that proxy's}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+public statement of acceptance of a version permanently authorizes you}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+to choose that version for the Program.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+Later license versions may give you additional or different}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+permissions.  However, no additional obligations are imposed on any}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+author or copyright holder as a result of your choosing to follow a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+later version.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+15. Disclaimer of Warranty.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+16. Limitation of Liability.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+SUCH DAMAGES.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+17. Interpretation of Sections 15 and 16.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+If the disclaimer of warranty and limitation of liability provided}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+above cannot be given local legal effect according to their terms,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+reviewing courts shall apply local law that most closely approximates}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+an absolute waiver of all civil liability in connection with the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+Program, unless a warranty or assumption of liability accompanies a}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+copy of the Program in return for a fee.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+                     }{\loch
+END OF TERMS AND CONDITIONS}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+            }{\loch
+How to Apply These Terms to Your New Programs}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+If you develop a new program, and you want it to be of the greatest}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+possible use to the public, the best way to achieve this is to make it}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+free software which everyone can redistribute and change under these terms.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+To do so, attach the following notices to the program.  It is safest}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+to attach them to the start of each source file to most effectively}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+state the exclusion of warranty; and each file should have at least}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+the "copyright" line and a pointer to where the full notice is found.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+<one line to give the program's name and a brief idea of what it does.>}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+Copyright (C) <year>  <name of author>}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+This program is free software: you can redistribute it and/or modify}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+it under the terms of the GNU General Public License as published by}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+the Free Software Foundation, either version 3 of the License, or}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+(at your option) any later version.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+This program is distributed in the hope that it will be useful,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+but WITHOUT ANY WARRANTY; without even the implied warranty of}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+GNU General Public License for more details.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+You should have received a copy of the GNU General Public License}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+along with this program.  If not, see <https://www.gnu.org/licenses/>.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+Also add information on how to contact you by electronic and paper mail.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+If the program does terminal interaction, make it output a short}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+notice like this when it starts in an interactive mode:}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+<program>  Copyright (C) <year>  <name of author>}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+This is free software, and you are welcome to redistribute it}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+    }{\loch
+under certain conditions; type `show c' for details.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+The hypothetical commands `show w' and `show c' should show the appropriate}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+parts of the General Public License.  Of course, your program's commands}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+might be different; for a GUI interface, you would use an "about box".}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+You should also get your employer (if you work as a programmer) or school,}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+if any, to sign a "copyright disclaimer" for the program, if necessary.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+For more information on this, and how to apply and follow the GNU GPL, see}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+<https://www.gnu.org/licenses/>.}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{
+  }{\loch
+The GNU General Public License does not permit incorporating your program}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+into proprietary programs.  If your program is a subroutine library, you}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+may consider it more useful to permit linking proprietary applications with}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+the library.  If this is what you want to do, use the GNU Lesser General}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+Public License instead of this License.  But first, please read}
+\par \pard\plain \s20\rtlch\af4\afs20 \ltrch\hich\af4\loch\sb0\sa0\f4\fs20\dbch\af7\ql\sb0\sa0\ltrpar{\loch
+<https://www.gnu.org/licenses/why-not-lgpl.html>.}
+\par }

--- a/src/windows_installer/README.rtf
+++ b/src/windows_installer/README.rtf
@@ -1,0 +1,129 @@
+{\rtf1\ansi\deff3\adeflang1025
+{\fonttbl{\f0\froman\fprq2\fcharset0 Times New Roman;}{\f1\froman\fprq2\fcharset2 Symbol;}{\f2\fswiss\fprq2\fcharset0 Arial;}{\f3\froman\fprq2\fcharset0 Liberation Serif{\*\falt Times New Roman};}{\f4\froman\fprq2\fcharset0 Liberation Sans{\*\falt Arial};}{\f5\froman\fprq2\fcharset0 Arial;}{\f6\fnil\fprq2\fcharset0 Microsoft YaHei;}{\f7\fnil\fprq2\fcharset0 0;}{\f8\fnil\fprq2\fcharset0 Lucida Sans;}}
+{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;}
+{\stylesheet{\s0\snext0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052 Normal;}
+{\*\cs15\snext15\loch\cf9\ul\ulc0 Hyperlink;}
+{\s16\sbasedon0\snext17\rtlch\af8\afs28\alang1081 \ltrch\lang1033\langfe2052\hich\af4\loch\ql\widctlpar\hyphpar0\sb240\sa120\keepn\ltrpar\cf0\f4\fs28\lang1033\kerning1\dbch\af6\langfe2052 Heading;}
+{\s17\sbasedon0\snext17\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\sl276\slmult1\widctlpar\hyphpar0\sb0\sa140\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052 Body Text;}
+{\s18\sbasedon17\snext18\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\sl276\slmult1\widctlpar\hyphpar0\sb0\sa140\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052 List;}
+{\s19\sbasedon0\snext19\rtlch\af8\afs24\alang1081\ai \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\sb120\sa120\ltrpar\cf0\f3\fs24\lang1033\i\kerning1\dbch\af7\langfe2052 Caption;}
+{\s20\sbasedon0\snext20\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052 Index;}
+}{\*\generator LibreOffice/7.6.4.1$Windows_X86_64 LibreOffice_project/e19e193f88cd6c0525a17fb7a176ed8e6a3e2aa1}{\info{\creatim\yr2023\mo12\dy25\hr23\min22}{\revtim\yr2023\mo12\dy26\hr13\min49}{\printim\yr0\mo0\dy0\hr0\min0}}{\*\userprops}\deftab709
+\hyphauto1\viewscale100\formshade\nobrkwrptbl\paperh15840\paperw12240\margl1134\margr1134\margt1134\margb1134\sectd\sbknone\sftnnar\saftnnrlc\sectunlocked1\pgwsxn12240\pghsxn15840\marglsxn1134\margrsxn1134\margtsxn1134\margbsxn1134\ftnbj\ftnstart1\ftnrstcont\ftnnar\aenddoc\aftnrstcont\aftnstart1\aftnnrlc
+{\*\ftnsep\chftnsep}\pgndec\pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\qc{\rtlch\afs30\ab \ltrch\hich\af5\loch\cf1\fs30\b\f5\loch
+MyoFInDer Windows application README}
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\qc\rtlch\ab \ltrch\hich\af5\loch\cf1\b\f5\loch
+
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql\rtlch\ab \ltrch\hich\af5\loch\cf1\b\f5\loch
+
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql{\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+This file is the README for the MyoFInDer }{\rtlch\ab \ltrch\hich\af5\loch\cf1\b\f5\loch
+desktop application}{\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+ for Windows. Its content only applies to the desktop application, and does not apply to MyoFInDer as a }{\rtlch\ab \ltrch\hich\af5\loch\cf1\b\f5\loch
+Python module}{\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+. For specific information on the Python module, please refer to the online documentation available at: }{{\field{\*\fldinst HYPERLINK "https://tissueengineeringlab.github.io/MyoFInDer/" }{\fldrslt {\rtlch\ab0 \ltrch\hich\af5\loch\cf9\ul\ulc0\b0\f5\loch
+https://tissueengineeringlab.github.io/MyoFInDer/}{}}}\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+.}
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql{\rtlch\afs26\ab \ltrch\hich\af5\loch\cf1\fs26\b\f5\loch
+Purpose}
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql{\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+The MyoFInDer desktop application for Windows is designed as a helper tool for users of the MyoFInDer Python module who are not familiar with Python and/or command-line operations. It serves two main purposes. First, it }{\rtlch\ab \ltrch\hich\af5\loch\cf1\b\f5\loch
+automatically handles the installation}{\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+ of the module in a clean way, without the user having to type a single command. Second, it creates desktop and startup-menu shortcuts, allowing users to }{\rtlch\ab \ltrch\hich\af5\loch\cf1\b\f5\loch
+run the Python module without typing commands}{\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+ in a terminal.}
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql{\rtlch\afs26\ab \ltrch\hich\af5\loch\cf1\fs26\b\f5\loch
+Installation}
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql{\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+The MyoFInDer desktop application is distributed in the }{\rtlch\ai\ab0 \ltrch\hich\af5\loch\cf1\i\b0\f5\loch
+myofinder.msi}{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+ executable installer, and can be }{\rtlch\ai0\ab \ltrch\hich\af5\loch\cf1\i0\b\f5\loch
+installed by simply double-clicking on the file}{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+. There is almost no specific requirement for installing it, neither in terms of hardware nor user privileges. The installation will however block if the }{\rtlch\ai0\ab \ltrch\hich\af5\loch\cf1\i0\b\f5\loch
+system memory is lower than 2048MB, or if no internet connection is available}{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+. Note that depending on the specific rules enforced in your company/organization, you might still be requested an administrator permission for installing MyoFInDer.}
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+Note that }{\rtlch\ai0\ab \ltrch\hich\af5\loch\cf1\i0\b\f5\loch
+installing}{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+ the MyoFInDer desktop application does not require to have Python installed, but }{\rtlch\ai0\ab \ltrch\hich\af5\loch\cf1\i0\b\f5\loch
+running}{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+ the application does. You should therefore install a compatible version of Python before running the application for the first time, see }{{\field{\*\fldinst HYPERLINK "https://tissueengineeringlab.github.io/MyoFInDer/installation.html" }{\fldrslt {\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf9\i0\ul\ulc0\b0\f5\loch
+https://tissueengineeringlab.github.io/MyoFInDer/installation.html}{}}}\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+ for more information.}
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+It is recommended to }{\rtlch\ai0\ab \ltrch\hich\af5\loch\cf1\i0\b\f5\loch
+check the }{\rtlch\ai\ab \ltrch\hich\af5\loch\cf1\i\b\f5\loch
+Launch MyoFInDer}{\rtlch\ai0\ab \ltrch\hich\af5\loch\cf1\i0\b\f5\loch
+ checkbox}{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+ at the end of the installation process, to start the application for the first time and complete the installation.}
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql{\rtlch\afs26\ai0\ab \ltrch\hich\af5\loch\cf1\fs26\i0\b\f5\loch
+Usage}
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+After installing MyoFInDer, you should be able to see new desktop and a startup menu shortcuts for the application. }{\rtlch\ai0\ab \ltrch\hich\af5\loch\cf1\i0\b\f5\loch
+Double-click on one of the shortcuts}{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+ to start the application for the first time (if it wasn\u8217\'92t already started at the end of the installation process). }{\rtlch\ai0\ab \ltrch\hich\af5\loch\cf1\i0\b\f5\loch
+A console window should appear}{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+, with various messages displayed in it. This console details the steps necessary to complete the installation. The whole process can take up to 10 minutes to complete. Once it is completed, }{\rtlch\ai0\ab \ltrch\hich\af5\loch\cf1\i0\b\f5\loch
+the interface of the MyoFInDer module should open}{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+. It is now ready to be used!}
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+The next time you click on a shortcut for opening the application, the same process will run (a console opens, runs a few checks), except MyoFInDer does not have to go through the installation process again. }{\rtlch\ai0\ab \ltrch\hich\af5\loch\cf1\i0\b\f5\loch
+The application should therefore only take a few dozen seconds to launch}{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+. You\u8217\'92ll find more information on how to use the interface of MyoFInDer on the following page: }{{\field{\*\fldinst HYPERLINK "https://tissueengineeringlab.github.io/MyoFInDer/usage.html" }{\fldrslt {\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf9\i0\ul\ulc0\b0\f5\loch
+https://tissueengineeringlab.github.io/MyoFInDer/usage.html}{}}}\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+.}
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql{\rtlch\afs26\ai0\ab \ltrch\hich\af5\loch\cf1\fs26\i0\b\f5\loch
+Troubleshooting}
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+If you face any problem with the installation or usage of MyoFInDer, }{\rtlch\ai0\ab \ltrch\hich\af5\loch\cf1\i0\b\f5\loch
+please report it}{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+ as detailed on the troubleshooting page: }{{\field{\*\fldinst HYPERLINK "https://tissueengineeringlab.github.io/MyoFInDer/troubleshooting.html" }{\fldrslt {\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf9\i0\ul\ulc0\b0\f5\loch
+https://tissueengineeringlab.github.io/MyoFInDer/troubleshooting.html}{}}}\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+. There are several ways }{\rtlch\ai0\ab \ltrch\hich\af5\loch\cf1\i0\b\f5\loch
+you can get support from the developers}{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+ of MyoFInDer, so do not hesitate to ask!}
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+Also, note that the MyoFInDer desktop application for Windows is only a helper tool distributed for convenience, it is not designed to meet any specific quality or stability standard. It is always possible to use MyoFInDer as a bare Python module, by running the correct commands in a terminal. }
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql{\rtlch\afs26\ai0\ab \ltrch\hich\af5\loch\cf1\fs26\i0\b\f5\loch
+Advanced information}
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+When executed, the installer creates a directory for the application, at }{\rtlch\ai\ab0 \ltrch\hich\af5\loch\cf1\i\b0\f5\loch
+C:\\Users\\<User>\\AppData\\Local\\MyoFInDer}{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+. In this directory, it places }{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+the license file and this README document. It also creates}{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+ a }{\rtlch\ai\ab0 \ltrch\hich\af5\loch\cf1\i\b0\f5\loch
+start_myofinder.bat}{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+ script, responsible for automatically managing the installation and startup of the Python module. The first time the batch script is run, a }{\rtlch\ai\ab0 \ltrch\hich\af5\loch\cf1\i\b0\f5\loch
+venv}{\rtlch\ai0\ab0 \ltrch\hich\af5\loch\cf1\i0\b0\f5\loch
+ directory is created that contains a virtual environment specific to MyoFInDer. In this environment, the Python module MyoFInDer and its dependencies are installed. After MyoFInDer has been started at least once, the application directory also contains the log file and the settings values.}
+\par \pard\plain \s0\rtlch\af8\afs24\alang1081 \ltrch\lang1033\langfe2052\hich\af3\loch\ql\widctlpar\hyphpar0\ltrpar\cf0\f3\fs24\lang1033\kerning1\dbch\af7\langfe2052\ql\rtlch\ab0 \ltrch\hich\af5\loch\cf1\b0\f5\loch
+
+\par }

--- a/src/windows_installer/config.aip
+++ b/src/windows_installer/config.aip
@@ -4,18 +4,23 @@
     <ROW Name="HiddenItems" Value="AppXProductDetailsComponent;AppXDependenciesComponent;AppXAppDetailsComponent;AppXVisualAssetsComponent;AppXCapabilitiesComponent;AppXAppDeclarationsComponent;AppXUriRulesComponent;FixupComponent;MsiXDiffComponent;MsixManifestEditorComponent"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiPropsComponent">
+    <ROW Property="AI_APP_FILE" Value="[#start_myofinder.bat]"/>
     <ROW Property="AI_BITMAP_DISPLAY_MODE" Value="0"/>
-    <ROW Property="AI_PREDEF_LCONDS_PROPS" Value="AI_DETECTED_ADMIN_USER"/>
+    <ROW Property="AI_PREDEF_LCONDS_PROPS" Value="AI_DETECTED_INTERNET_CONNECTION;AI_DETECTED_PHYSICAL_MEMORY"/>
+    <ROW Property="AI_REQUIRED_PHYSICAL_MEMORY" MultiBuildValue="DefaultBuild:2048" ValueLocId="-"/>
     <ROW Property="ALLUSERS" Value="1" MultiBuildValue="DefaultBuild:"/>
     <ROW Property="ARPCOMMENTS" Value="This installer database contains the logic and data required to install [|ProductName]." ValueLocId="*"/>
     <ROW Property="ARPHELPLINK" Value="https://github.com/TissueEngineeringLab/MyoFInDer"/>
     <ROW Property="ARPPRODUCTICON" Value="project_icon.exe" Type="8"/>
     <ROW Property="ARPURLINFOABOUT" Value="https://github.com/TissueEngineeringLab/MyoFInDer"/>
+    <ROW Property="CTRLS" Value="2"/>
     <ROW Property="Manufacturer" Value="Tissue Engineering Lab - KU Leuven"/>
+    <ROW Property="MsiLogging" MultiBuildValue="DefaultBuild:vp"/>
     <ROW Property="ProductCode" Value="1033:{BFA51019-B48F-475B-B8BB-E2F14499079C} " Type="16"/>
     <ROW Property="ProductLanguage" Value="1033"/>
     <ROW Property="ProductName" Value="MyoFInDer"/>
     <ROW Property="ProductVersion" Value="1.0.7" Options="32"/>
+    <ROW Property="RUNAPPLICATION" Value="1" Type="4"/>
     <ROW Property="SecureCustomProperties" Value="OLDPRODUCTS;AI_NEWERPRODUCTFOUND"/>
     <ROW Property="UpgradeCode" Value="{CE95562D-8E91-4ED9-B26E-5638FFE5C0B0}"/>
     <ROW Property="WindowsType9X" MultiBuildValue="DefaultBuild:Windows 9x/ME" ValueLocId="-"/>
@@ -36,7 +41,6 @@
     <ROW Directory="TARGETDIR" DefaultDir="SourceDir"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiCompsComponent">
-    <ROW Component="AI_INSTALLPERUSER" ComponentId="{EC283441-1F93-495A-901B-DA20901AC292}" Directory_="APPDIR" Attributes="4" KeyPath="AI_INSTALLPERUSER" Options="1"/>
     <ROW Component="APPDIR" ComponentId="{F813A2C8-6F92-4A2D-A4A9-CC61510ED80A}" Directory_="APPDIR" Attributes="0"/>
     <ROW Component="ProductInformation" ComponentId="{BDBA81E5-36AF-452D-B9A0-2B8E5532AED9}" Directory_="APPDIR" Attributes="4" KeyPath="Version"/>
     <ROW Component="SHORTCUTDIR" ComponentId="{DCB2898B-10B0-4722-A576-3C002DC12283}" Directory_="SHORTCUTDIR" Attributes="0"/>
@@ -48,9 +52,6 @@
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiFilesComponent">
     <ROW File="start_myofinder.bat" Component_="start_myofinder.bat" FileName="START_~1.BAT|start_myofinder.bat" Attributes="0" SourcePath="start_myofinder.bat" SelfReg="false"/>
-  </COMPONENT>
-  <COMPONENT cid="caphyon.advinst.msicomp.AiPersistentPropComponent">
-    <ROW Property="AI_INSTALLPERUSER" Registry="AI_INSTALLPERUSER" HklmSearch="AI_INSTALLPERUSER" HkcuSearch="AI_INSTALLPERUSER_1"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.BootstrOptComponent">
     <ROW BootstrOptKey="GlobalOptions" DownloadFolder="[AppDataFolder][|Manufacturer]\[|ProductName]\prerequisites" Options="2"/>
@@ -67,8 +68,6 @@
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.FragmentComponent">
     <ROW Fragment="CommonUI.aip" Path="&lt;AI_FRAGS&gt;CommonUI.aip"/>
-    <ROW Fragment="FolderDlg.aip" Path="&lt;AI_THEMES&gt;classic\fragments\FolderDlg.aip"/>
-    <ROW Fragment="InstallTypeDlg.aip" Path="&lt;AI_THEMES&gt;classic\fragments\InstallTypeDlg.aip"/>
     <ROW Fragment="MaintenanceTypeDlg.aip" Path="&lt;AI_THEMES&gt;classic\fragments\MaintenanceTypeDlg.aip"/>
     <ROW Fragment="MaintenanceWelcomeDlg.aip" Path="&lt;AI_THEMES&gt;classic\fragments\MaintenanceWelcomeDlg.aip"/>
     <ROW Fragment="SequenceDialogs.aip" Path="&lt;AI_THEMES&gt;classic\fragments\SequenceDialogs.aip"/>
@@ -81,23 +80,18 @@
     <ROW Fragment="VerifyRepairDlg.aip" Path="&lt;AI_THEMES&gt;classic\fragments\VerifyRepairDlg.aip"/>
     <ROW Fragment="WelcomeDlg.aip" Path="&lt;AI_THEMES&gt;classic\fragments\WelcomeDlg.aip"/>
   </COMPONENT>
-  <COMPONENT cid="caphyon.advinst.msicomp.MsiAppSearchComponent">
-    <ROW Property="AI_INSTALLPERUSER" Signature_="AI_INSTALLPERUSER"/>
-    <ROW Property="AI_INSTALLPERUSER" Signature_="AI_INSTALLPERUSER_1"/>
-  </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiBinaryComponent">
+    <ROW Name="ShortcutFlags.dll" SourcePath="&lt;AI_CUSTACTS&gt;ShortcutFlags.dll"/>
     <ROW Name="SoftwareDetector.dll" SourcePath="&lt;AI_CUSTACTS&gt;SoftwareDetector.dll"/>
     <ROW Name="aicustact.dll" SourcePath="&lt;AI_CUSTACTS&gt;aicustact.dll"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiControlEventComponent">
-    <ROW Dialog_="WelcomeDlg" Control_="Next" Event="NewDialog" Argument="FolderDlg" Condition="AI_INSTALL" Ordering="1"/>
-    <ROW Dialog_="FolderDlg" Control_="Next" Event="NewDialog" Argument="VerifyReadyDlg" Condition="AI_INSTALL" Ordering="201"/>
-    <ROW Dialog_="FolderDlg" Control_="Back" Event="NewDialog" Argument="WelcomeDlg" Condition="AI_INSTALL" Ordering="1"/>
+    <ROW Dialog_="WelcomeDlg" Control_="Next" Event="NewDialog" Argument="VerifyReadyDlg" Condition="AI_INSTALL" Ordering="1"/>
     <ROW Dialog_="MaintenanceWelcomeDlg" Control_="Next" Event="NewDialog" Argument="MaintenanceTypeDlg" Condition="AI_MAINT" Ordering="99"/>
     <ROW Dialog_="VerifyReadyDlg" Control_="Install" Event="EndDialog" Argument="Return" Condition="AI_MAINT" Ordering="198"/>
-    <ROW Dialog_="VerifyReadyDlg" Control_="Back" Event="NewDialog" Argument="CustomizeDlg" Condition="AI_MAINT" Ordering="202"/>
+    <ROW Dialog_="VerifyReadyDlg" Control_="Back" Event="NewDialog" Argument="CustomizeDlg" Condition="AI_MAINT" Ordering="204"/>
     <ROW Dialog_="VerifyReadyDlg" Control_="Install" Event="EndDialog" Argument="Return" Condition="AI_INSTALL" Ordering="197"/>
-    <ROW Dialog_="VerifyReadyDlg" Control_="Back" Event="NewDialog" Argument="FolderDlg" Condition="AI_INSTALL" Ordering="201"/>
+    <ROW Dialog_="VerifyReadyDlg" Control_="Back" Event="NewDialog" Argument="WelcomeDlg" Condition="AI_INSTALL" Ordering="201"/>
     <ROW Dialog_="CustomizeDlg" Control_="Next" Event="NewDialog" Argument="VerifyReadyDlg" Condition="AI_MAINT" Ordering="101"/>
     <ROW Dialog_="CustomizeDlg" Control_="Back" Event="NewDialog" Argument="MaintenanceTypeDlg" Condition="AI_MAINT" Ordering="1"/>
     <ROW Dialog_="MaintenanceTypeDlg" Control_="ChangeButton" Event="NewDialog" Argument="CustomizeDlg" Condition="AI_MAINT" Ordering="501"/>
@@ -111,25 +105,34 @@
     <ROW Dialog_="PatchWelcomeDlg" Control_="Next" Event="NewDialog" Argument="VerifyReadyDlg" Condition="AI_PATCH" Ordering="201"/>
     <ROW Dialog_="ResumeDlg" Control_="Install" Event="EndDialog" Argument="Return" Condition="AI_RESUME" Ordering="299"/>
     <ROW Dialog_="VerifyReadyDlg" Control_="Install" Event="EndDialog" Argument="Return" Condition="AI_PATCH" Ordering="199"/>
-    <ROW Dialog_="VerifyReadyDlg" Control_="Back" Event="NewDialog" Argument="PatchWelcomeDlg" Condition="AI_PATCH" Ordering="203"/>
+    <ROW Dialog_="VerifyReadyDlg" Control_="Back" Event="NewDialog" Argument="PatchWelcomeDlg" Condition="AI_PATCH" Ordering="205"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiCreateFolderComponent">
     <ROW Directory_="APPDIR" Component_="APPDIR" ManualDelete="true"/>
     <ROW Directory_="SHORTCUTDIR" Component_="SHORTCUTDIR" ManualDelete="false"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiCustActComponent">
-    <ROW Action="AI_AuthorSinglePackage" Type="1" Source="aicustact.dll" Target="AI_AuthorSinglePackage" WithoutSeq="true"/>
+    <ROW Action="AI_ApplyShortcutFlags" Type="3073" Source="ShortcutFlags.dll" Target="UpdateShortcutFlags" WithoutSeq="true"/>
     <ROW Action="AI_DOWNGRADE" Type="19" Target="4010"/>
     <ROW Action="AI_DetectSoftware" Type="257" Source="SoftwareDetector.dll" Target="OnDetectSoftware"/>
     <ROW Action="AI_DpiContentScale" Type="1" Source="aicustact.dll" Target="DpiContentScale"/>
     <ROW Action="AI_EnableDebugLog" Type="321" Source="aicustact.dll" Target="EnableDebugLog"/>
     <ROW Action="AI_InstallModeCheck" Type="1" Source="aicustact.dll" Target="UpdateInstallMode" WithoutSeq="true"/>
+    <ROW Action="AI_LaunchApp" Type="1" Source="aicustact.dll" Target="LaunchApp"/>
     <ROW Action="AI_PREPARE_UPGRADE" Type="65" Source="aicustact.dll" Target="PrepareUpgrade"/>
     <ROW Action="AI_PRESERVE_INSTALL_TYPE" Type="65" Source="aicustact.dll" Target="PreserveInstallType"/>
+    <ROW Action="AI_PinShortcuts" Type="1" Source="ShortcutFlags.dll" Target="PinShortcuts"/>
+    <ROW Action="AI_PinToStartScreen" Type="1025" Source="ShortcutFlags.dll" Target="PinToStartScreen" WithoutSeq="true"/>
+    <ROW Action="AI_PinToTaskbar" Type="1025" Source="ShortcutFlags.dll" Target="PinToTaskbar" WithoutSeq="true"/>
+    <ROW Action="AI_PrepareShortcutFlags" Type="1" Source="ShortcutFlags.dll" Target="PrepareActionData"/>
     <ROW Action="AI_RESTORE_LOCATION" Type="65" Source="aicustact.dll" Target="RestoreLocation"/>
     <ROW Action="AI_ResolveKnownFolders" Type="1" Source="aicustact.dll" Target="AI_ResolveKnownFolders"/>
     <ROW Action="AI_SHOW_LOG" Type="65" Source="aicustact.dll" Target="LaunchLogFile" WithoutSeq="true"/>
     <ROW Action="AI_STORE_LOCATION" Type="51" Source="ARPINSTALLLOCATION" Target="[APPDIR]"/>
+    <ROW Action="AI_UnpinFromStartScreen" Type="1025" Source="ShortcutFlags.dll" Target="UnpinFromStartScreen" WithoutSeq="true"/>
+    <ROW Action="AI_UnpinFromTaskbar" Type="1025" Source="ShortcutFlags.dll" Target="UnpinFromTaskbar" WithoutSeq="true"/>
+    <ROW Action="AI_UnpinShortcuts" Type="1" Source="ShortcutFlags.dll" Target="UnpinShortcuts"/>
+    <ROW Action="AI_ViewReadme" Type="1" Source="aicustact.dll" Target="ViewReadMe"/>
     <ROW Action="SET_APPDIR" Type="307" Source="APPDIR" Target="[ProgramFilesFolder][Manufacturer]\[ProductName]" MultiBuildTarget="DefaultBuild:[LocalAppDataFolder]\[ProductName]"/>
     <ROW Action="SET_SHORTCUTDIR" Type="307" Source="SHORTCUTDIR" Target="[ProgramMenuFolder][ProductName]"/>
     <ROW Action="SET_TARGETDIR_TO_APPDIR" Type="51" Source="TARGETDIR" Target="[APPDIR]"/>
@@ -138,7 +141,6 @@
     <ROW Feature_="MainFeature" Component_="APPDIR"/>
     <ROW Feature_="MainFeature" Component_="ProductInformation"/>
     <ROW Feature_="MainFeature" Component_="SHORTCUTDIR"/>
-    <ROW Feature_="MainFeature" Component_="AI_INSTALLPERUSER"/>
     <ROW Feature_="MainFeature" Component_="start_myofinder.bat"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiIconsComponent">
@@ -153,6 +155,9 @@
     <ROW Action="AI_ResolveKnownFolders" Sequence="52"/>
     <ROW Action="AI_EnableDebugLog" Sequence="51"/>
     <ROW Action="AI_DetectSoftware" Sequence="101"/>
+    <ROW Action="AI_PrepareShortcutFlags" Condition="(VersionNT &gt; 501) AND ((NOT Installed) OR (Installed AND (REMOVE&lt;&gt;&quot;ALL&quot;) AND (AI_INSTALL_MODE&lt;&gt;&quot;Remove&quot;)))" Sequence="4501"/>
+    <ROW Action="AI_PinShortcuts" Condition="(VersionNT &gt; 600) AND ((NOT Installed) OR (Installed AND (REMOVE&lt;&gt;&quot;ALL&quot;) AND (AI_INSTALL_MODE&lt;&gt;&quot;Remove&quot;)))" Sequence="6499"/>
+    <ROW Action="AI_UnpinShortcuts" Condition="(VersionNT &gt; 600) AND (REMOVE = &quot;ALL&quot;)" Sequence="3199"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiInstallUISequenceComponent">
     <ROW Action="AI_PRESERVE_INSTALL_TYPE" Sequence="199"/>
@@ -166,31 +171,27 @@
     <ROW Condition="((VersionNT &lt;&gt; 501) AND (VersionNT &lt;&gt; 502))" Description="[ProductName] cannot be installed on [WindowsTypeNT5XDisplay]." DescriptionLocId="AI.LaunchCondition.NoNT5X" IsPredefined="true" Builds="DefaultBuild"/>
     <ROW Condition="(VersionNT &lt;&gt; 400)" Description="[ProductName] cannot be installed on [WindowsTypeNT40Display]." DescriptionLocId="AI.LaunchCondition.NoNT40" IsPredefined="true" Builds="DefaultBuild"/>
     <ROW Condition="(VersionNT &lt;&gt; 500)" Description="[ProductName] cannot be installed on [WindowsTypeNT50Display]." DescriptionLocId="AI.LaunchCondition.NoNT50" IsPredefined="true" Builds="DefaultBuild"/>
+    <ROW Condition="AI_DETECTED_INTERNET_CONNECTION" Description="[ProductName] requires an active Internet connection for installation. Please check your network configuration and proxy settings." DescriptionLocId="AI.LaunchCondition.Internet" IsPredefined="true" Builds="DefaultBuild"/>
+    <ROW Condition="AI_DETECTED_PHYSICAL_MEMORY &gt;= AI_REQUIRED_PHYSICAL_MEMORY" Description="[ProductName] cannot be installed on systems with less physical memory than [AI_REQUIRED_PHYSICAL_MEMORY] MB." DescriptionLocId="AI.LaunchCondition.RAM" IsPredefined="true" Builds="DefaultBuild"/>
     <ROW Condition="VersionNT" Description="[ProductName] cannot be installed on [WindowsType9XDisplay]." DescriptionLocId="AI.LaunchCondition.No9X" IsPredefined="true" Builds="DefaultBuild"/>
   </COMPONENT>
-  <COMPONENT cid="caphyon.advinst.msicomp.MsiRegLocatorComponent">
-    <ROW Signature_="AI_INSTALLPERUSER" Root="2" Key="Software\[Manufacturer]\[UpgradeCode]" Name="AI_INSTALLPERUSER" Type="2"/>
-    <ROW Signature_="AI_INSTALLPERUSER_1" Root="1" Key="Software\[Manufacturer]\[UpgradeCode]" Name="AI_INSTALLPERUSER" Type="2"/>
-  </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiRegsComponent">
-    <ROW Registry="AI_INSTALLPERUSER" Root="-1" Key="Software\[Manufacturer]\[UpgradeCode]" Name="AI_INSTALLPERUSER" Value="[AI_INSTALLPERUSER]" Component_="AI_INSTALLPERUSER"/>
     <ROW Registry="Manufacturer" Root="-1" Key="Software\[Manufacturer]" Name="\"/>
     <ROW Registry="Path" Root="-1" Key="Software\[Manufacturer]\[ProductName]" Name="Path" Value="[APPDIR]" Component_="ProductInformation"/>
     <ROW Registry="ProductName" Root="-1" Key="Software\[Manufacturer]\[ProductName]" Name="\"/>
     <ROW Registry="Software" Root="-1" Key="Software" Name="\"/>
-    <ROW Registry="UpgradeCode" Root="-1" Key="Software\[Manufacturer]\[UpgradeCode]" Name="\"/>
     <ROW Registry="Version" Root="-1" Key="Software\[Manufacturer]\[ProductName]" Name="Version" Value="[ProductVersion]" Component_="ProductInformation"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiShortsComponent">
-    <ROW Shortcut="ProductName" Directory_="DesktopFolder" Name="MYOFIN~1|[|ProductName]" Component_="APPDIR" Target="[LocalAppDataFolder]\[ProductName]\start_myofinder.bat" Hotkey="0" Icon_="project_icon.exe" IconIndex="0" ShowCmd="1" WkDir="NewFolder_Dir"/>
-    <ROW Shortcut="ProductName_1" Directory_="SHORTCUTDIR" Name="MYOFIN~1|[|ProductName]" Component_="ProductInformation" Target="[LocalAppDataFolder]\[ProductName]\start_myofinder.bat" Hotkey="0" Icon_="project_icon.exe" IconIndex="0" ShowCmd="1" WkDir="NewFolder_Dir"/>
-    <ROW Shortcut="UninstallProductName" Directory_="SHORTCUTDIR" Name="UNINST~1|Uninstall [|ProductName]" Component_="ProductInformation" Target="[SystemFolder]msiexec.exe" Arguments="/x [ProductCode]" Hotkey="0" Icon_="SystemFoldermsiexec.exe" IconIndex="0" ShowCmd="1"/>
+    <ROW Shortcut="ProductName" Directory_="DesktopFolder" Name="MYOFIN~1|[|ProductName]" Component_="APPDIR" Target="[LocalAppDataFolder]\[ProductName]\start_myofinder.bat" Description="Shortcut for starting [|ProductName] from the desktop" Hotkey="0" Icon_="project_icon.exe" IconIndex="0" ShowCmd="1" WkDir="NewFolder_Dir" CustomFlags="2"/>
+    <ROW Shortcut="ProductName_1" Directory_="SHORTCUTDIR" Name="MYOFIN~1|[|ProductName]" Component_="ProductInformation" Target="[LocalAppDataFolder]\[ProductName]\start_myofinder.bat" Description="Shortcut for starting [|ProductName] from the startup menu" Hotkey="0" Icon_="project_icon.exe" IconIndex="0" ShowCmd="1" WkDir="NewFolder_Dir" CustomFlags="2"/>
+    <ROW Shortcut="UninstallProductName" Directory_="SHORTCUTDIR" Name="UNINST~1|Uninstall [|ProductName]" Component_="ProductInformation" Target="[SystemFolder]msiexec.exe" Arguments="/x [ProductCode]" Description="Shortcut for uninstalling [|ProductName]" Hotkey="0" Icon_="SystemFoldermsiexec.exe" IconIndex="0" ShowCmd="1"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiThemeComponent">
     <ATTRIBUTE name="UsedTheme" value="classic"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiUpgradeComponent">
-    <ROW UpgradeCode="[|UpgradeCode]" VersionMin="0.0.1" VersionMax="[|ProductVersion]" Attributes="257" ActionProperty="OLDPRODUCTS"/>
-    <ROW UpgradeCode="[|UpgradeCode]" VersionMin="[|ProductVersion]" Attributes="2" ActionProperty="AI_NEWERPRODUCTFOUND"/>
+    <ROW UpgradeCode="[|UpgradeCode]" VersionMin="0.0.1" VersionMax="255.255.6555.6555" Attributes="257" ActionProperty="OLDPRODUCTS"/>
+    <ROW UpgradeCode="[|UpgradeCode]" VersionMin="255.255.6555.6555" Attributes="2" ActionProperty="AI_NEWERPRODUCTFOUND"/>
   </COMPONENT>
 </DOCUMENT>

--- a/src/windows_installer/config.aip
+++ b/src/windows_installer/config.aip
@@ -7,13 +7,14 @@
     <ROW Property="AI_APP_FILE" Value="[#start_myofinder.bat]"/>
     <ROW Property="AI_BITMAP_DISPLAY_MODE" Value="0"/>
     <ROW Property="AI_PREDEF_LCONDS_PROPS" Value="AI_DETECTED_INTERNET_CONNECTION;AI_DETECTED_PHYSICAL_MEMORY"/>
+    <ROW Property="AI_README_FILE" Value="[#README.rtf]"/>
     <ROW Property="AI_REQUIRED_PHYSICAL_MEMORY" MultiBuildValue="DefaultBuild:2048" ValueLocId="-"/>
     <ROW Property="ALLUSERS" Value="1" MultiBuildValue="DefaultBuild:"/>
     <ROW Property="ARPCOMMENTS" Value="This installer database contains the logic and data required to install [|ProductName]." ValueLocId="*"/>
     <ROW Property="ARPHELPLINK" Value="https://github.com/TissueEngineeringLab/MyoFInDer"/>
     <ROW Property="ARPPRODUCTICON" Value="project_icon.exe" Type="8"/>
     <ROW Property="ARPURLINFOABOUT" Value="https://github.com/TissueEngineeringLab/MyoFInDer"/>
-    <ROW Property="CTRLS" Value="2"/>
+    <ROW Property="CTRLS" Value="3"/>
     <ROW Property="Manufacturer" Value="Tissue Engineering Lab - KU Leuven"/>
     <ROW Property="MsiLogging" MultiBuildValue="DefaultBuild:vp"/>
     <ROW Property="ProductCode" Value="1033:{BFA51019-B48F-475B-B8BB-E2F14499079C} " Type="16"/>
@@ -23,6 +24,7 @@
     <ROW Property="RUNAPPLICATION" Value="1" Type="4"/>
     <ROW Property="SecureCustomProperties" Value="OLDPRODUCTS;AI_NEWERPRODUCTFOUND"/>
     <ROW Property="UpgradeCode" Value="{CE95562D-8E91-4ED9-B26E-5638FFE5C0B0}"/>
+    <ROW Property="VIEWREADME" Value="1" Type="4"/>
     <ROW Property="WindowsType9X" MultiBuildValue="DefaultBuild:Windows 9x/ME" ValueLocId="-"/>
     <ROW Property="WindowsType9XDisplay" MultiBuildValue="DefaultBuild:Windows 9x/ME" ValueLocId="-"/>
     <ROW Property="WindowsTypeNT40" MultiBuildValue="DefaultBuild:Windows NT 4.0" ValueLocId="-"/>
@@ -52,6 +54,8 @@
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiFilesComponent">
     <ROW File="start_myofinder.bat" Component_="start_myofinder.bat" FileName="START_~1.BAT|start_myofinder.bat" Attributes="0" SourcePath="start_myofinder.bat" SelfReg="false"/>
+    <ROW File="README.rtf" Component_="start_myofinder.bat" FileName="README.rtf" Attributes="0" SourcePath="README.rtf" SelfReg="false"/>
+    <ROW File="LICENSE.rtf" Component_="start_myofinder.bat" FileName="LICENSE.rtf" Attributes="0" SourcePath="LICENSE.rtf" SelfReg="false"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.BootstrOptComponent">
     <ROW BootstrOptKey="GlobalOptions" DownloadFolder="[AppDataFolder][|Manufacturer]\[|ProductName]\prerequisites" Options="2"/>
@@ -68,6 +72,7 @@
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.FragmentComponent">
     <ROW Fragment="CommonUI.aip" Path="&lt;AI_FRAGS&gt;CommonUI.aip"/>
+    <ROW Fragment="LicenseAgreementDlg.aip" Path="&lt;AI_THEMES&gt;classic\fragments\LicenseAgreementDlg.aip"/>
     <ROW Fragment="MaintenanceTypeDlg.aip" Path="&lt;AI_THEMES&gt;classic\fragments\MaintenanceTypeDlg.aip"/>
     <ROW Fragment="MaintenanceWelcomeDlg.aip" Path="&lt;AI_THEMES&gt;classic\fragments\MaintenanceWelcomeDlg.aip"/>
     <ROW Fragment="SequenceDialogs.aip" Path="&lt;AI_THEMES&gt;classic\fragments\SequenceDialogs.aip"/>
@@ -85,13 +90,16 @@
     <ROW Name="SoftwareDetector.dll" SourcePath="&lt;AI_CUSTACTS&gt;SoftwareDetector.dll"/>
     <ROW Name="aicustact.dll" SourcePath="&lt;AI_CUSTACTS&gt;aicustact.dll"/>
   </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiControlComponent">
+    <ROW Dialog_="LicenseAgreementDlg" Control="AgreementText" Type="ScrollableText" X="20" Y="60" Width="330" Height="120" Attributes="7" Text="LICENSE.rtf" Order="400" TextLocId="Control.Text.LicenseAgreementDlg#AgreementText" MsiKey="LicenseAgreementDlg#AgreementText"/>
+  </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiControlEventComponent">
-    <ROW Dialog_="WelcomeDlg" Control_="Next" Event="NewDialog" Argument="VerifyReadyDlg" Condition="AI_INSTALL" Ordering="1"/>
+    <ROW Dialog_="WelcomeDlg" Control_="Next" Event="NewDialog" Argument="LicenseAgreementDlg" Condition="AI_INSTALL" Ordering="1"/>
     <ROW Dialog_="MaintenanceWelcomeDlg" Control_="Next" Event="NewDialog" Argument="MaintenanceTypeDlg" Condition="AI_MAINT" Ordering="99"/>
     <ROW Dialog_="VerifyReadyDlg" Control_="Install" Event="EndDialog" Argument="Return" Condition="AI_MAINT" Ordering="198"/>
     <ROW Dialog_="VerifyReadyDlg" Control_="Back" Event="NewDialog" Argument="CustomizeDlg" Condition="AI_MAINT" Ordering="204"/>
     <ROW Dialog_="VerifyReadyDlg" Control_="Install" Event="EndDialog" Argument="Return" Condition="AI_INSTALL" Ordering="197"/>
-    <ROW Dialog_="VerifyReadyDlg" Control_="Back" Event="NewDialog" Argument="WelcomeDlg" Condition="AI_INSTALL" Ordering="201"/>
+    <ROW Dialog_="VerifyReadyDlg" Control_="Back" Event="NewDialog" Argument="LicenseAgreementDlg" Condition="AI_INSTALL" Ordering="201"/>
     <ROW Dialog_="CustomizeDlg" Control_="Next" Event="NewDialog" Argument="VerifyReadyDlg" Condition="AI_MAINT" Ordering="101"/>
     <ROW Dialog_="CustomizeDlg" Control_="Back" Event="NewDialog" Argument="MaintenanceTypeDlg" Condition="AI_MAINT" Ordering="1"/>
     <ROW Dialog_="MaintenanceTypeDlg" Control_="ChangeButton" Event="NewDialog" Argument="CustomizeDlg" Condition="AI_MAINT" Ordering="501"/>
@@ -106,6 +114,8 @@
     <ROW Dialog_="ResumeDlg" Control_="Install" Event="EndDialog" Argument="Return" Condition="AI_RESUME" Ordering="299"/>
     <ROW Dialog_="VerifyReadyDlg" Control_="Install" Event="EndDialog" Argument="Return" Condition="AI_PATCH" Ordering="199"/>
     <ROW Dialog_="VerifyReadyDlg" Control_="Back" Event="NewDialog" Argument="PatchWelcomeDlg" Condition="AI_PATCH" Ordering="205"/>
+    <ROW Dialog_="LicenseAgreementDlg" Control_="Next" Event="NewDialog" Argument="VerifyReadyDlg" Condition="AI_INSTALL" Ordering="1"/>
+    <ROW Dialog_="LicenseAgreementDlg" Control_="Back" Event="NewDialog" Argument="WelcomeDlg" Condition="AI_INSTALL" Ordering="1"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiCreateFolderComponent">
     <ROW Directory_="APPDIR" Component_="APPDIR" ManualDelete="true"/>


### PR DESCRIPTION
So far, the Windows installer was very basic and featured only the bare minimum implementation. With this PR, the installer gets a bit nicer, with the inclusion of a README and a LICENSE file. The user now has to agree with the license terms, and can choose to open the README file once the installation has completed. Users can also chose to start MyoFInDer right after finishing the installation.

Using only the free version of Advanced Installer, there's not much more improvements that can be brought to the Windows installer. This is however not a big deal, as the installer is designed as a convenience tool and should remain as simple as possible.