### PR TITLE
Fixes in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,18 +35,16 @@ Issues = "https://github.com/TissueEngineeringLab/MyoFInDer/issues"
 Download = "https://pypi.org/project/myofinder/#files"
 
 [tool.setuptools]
-include-package-data = true
+package-dir = {"" = "src"}
+include-package-data = false
 
 [tool.setuptools.dynamic]
 readme = {file = "README.md", content-type = "text/markdown"}
 dependencies = {file = "requirements.txt"}
 
-[tool.setuptools.package-dir]
-crappy = "src/myofinder"
-
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["*"]
+include = ["myofinder*"]
 exclude = []
 namespaces = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,11 @@
 [build-system]
-requires = [
-    "setuptools >= 61.0",
-    "screeninfo",
-    "Pillow",
-    "opencv-python",
-    "XlsxWriter",
-    "DeepCell"
-]
+requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "myofinder"
-dynamic = ["version", "readme", "dependencies"]
+dynamic = ["readme", "dependencies"]
+version = "1.0.7"
 description = "Automatic calculation of the fusion index by AI segmentation"
 license = {file = "LICENSE"}
 keywords = ["segmentation", "fusion index", "automation", "muscle culture"]
@@ -44,7 +38,6 @@ Download = "https://pypi.org/project/myofinder/#files"
 include-package-data = true
 
 [tool.setuptools.dynamic]
-version = {attr = "myofinder.__version__"}
 readme = {file = "README.md", content-type = "text/markdown"}
 dependencies = {file = "requirements.txt"}
 


### PR DESCRIPTION
This PR fixes two minor problems that were introduced in #32 when switching from `setup.py` to `pyproject.toml`:
* The runtime dependencies of the module had also become build dependencies. This behavior was not intended, and was caused by the dynamic lookup of the module version in `pyproject.toml`, that was requiring to install the module at build-time. It was fixed by making the project version a static field of `pyproject.toml` (25f8430e).
* The editable install (`python -m pip install -e .`) was broken on Windows (still working on Linux, curiously). It was due to an incorrect combination of settings in the section of `pyproject.toml` managing setuptools options. It was fixed by editing the broken fields to a correct syntax (5dfec3e3).