### PR TITLE
Bug on macOS when running MyoFInDer

### DIFF
--- a/src/myofinder/main_window.py
+++ b/src/myofinder/main_window.py
@@ -79,7 +79,7 @@ class MainWindow(Tk):
         # Initializes the main window
         super().__init__()
         self.title("MyoFInDer - New Project (Unsaved)")
-        if system() == "Windows":
+        if system() in ("Windows", "Darwin"):
             self.state('zoomed')
         else:
             self.attributes('-zoomed', True)


### PR DESCRIPTION
When running MyoFInDer on a macOS machine, the main window crashes right at initialization. This is due to the `'-zoomed'` attribute of the main window being used instead of `'zoomed'`:

https://github.com/TissueEngineeringLab/MyoFInDer/blob/37911a95a523b78c5d573ed563ed385ae1c0c5c1/src/myofinder/main_window.py#L82-L85

This PR fixes the bug by using the `'zoomed'` attribute on both Windows and Darwin platforms.