### PR TITLE
Read application folder from registry

### DIFF
--- a/.github/workflows/build_windows_installer.yml
+++ b/.github/workflows/build_windows_installer.yml
@@ -150,7 +150,7 @@ jobs:
       # Run the installed MyoFInDer program
       - name: Run MyoFInDer
         shell: cmd
-        run: '"%localappdata%\MyoFInDer\myofinder.exe" -t'
+        run: '"%localappdata%\MyoFInDer\myofinder.exe" --test'
 
   # Pushes the installer to the main branch
   push-installer:

--- a/src/myofinder/__main__.py
+++ b/src/myofinder/__main__.py
@@ -41,7 +41,7 @@ def main():
     # Retrieving the command-line arguments
     log: bool = args.nolog
     test: bool = args.test
-    app_folder: Optional[Path] = args.app_folder
+    app_folder: Optional[Path] = args.app_folder[0]
 
     # Setting the path to the application folder if not already provided
     if app_folder is None:

--- a/src/myofinder/__main__.py
+++ b/src/myofinder/__main__.py
@@ -41,7 +41,11 @@ def main():
     # Retrieving the command-line arguments
     log: bool = args.nolog
     test: bool = args.test
-    app_folder: Optional[Path] = args.app_folder[0]
+    app_folder: Optional[Path]
+    if args.app_folder is None:
+        app_folder = None
+    else:
+        app_folder = args.app_folder[0]
 
     # Setting the path to the application folder if not already provided
     if app_folder is None:

--- a/src/myofinder/__main__.py
+++ b/src/myofinder/__main__.py
@@ -9,6 +9,7 @@ from sys import stdout, exit
 from pathlib import Path
 import argparse
 from platform import system
+from typing import Optional
 
 
 def main():
@@ -30,19 +31,24 @@ def main():
                         help="If provided, the main window is created but its "
                              "main loop is never started and the window is "
                              "destroyed as soon as it is initialized.")
+    parser.add_argument('-f', '--app-folder', action='store', nargs=1,
+                        type=Path, required=False, dest='app_folder',
+                        help="If provided, should contain the path to the "
+                             "folder where to store the log messages and the "
+                             "settings file.")
     args = parser.parse_args()
 
     # Retrieving the command-line arguments
     log: bool = args.nolog
     test: bool = args.test
+    app_folder: Optional[Path] = args.app_folder
 
-    # Setting the path to the application folder
-    if system() in ('Linux', 'Darwin'):
-        app_folder = Path.home() / '.MyoFInDer'
-    elif system() == 'Windows':
-        app_folder = (Path.home() / 'AppData' / 'Local' / 'MyoFInDer')
-    else:
-        app_folder = None
+    # Setting the path to the application folder if not already provided
+    if app_folder is None:
+        if system() in ('Linux', 'Darwin'):
+            app_folder = Path.home() / '.MyoFInDer'
+        elif system() == 'Windows':
+            app_folder = (Path.home() / 'AppData' / 'Local' / 'MyoFInDer')
 
     # Creating the application folder, if needed
     if app_folder is not None:

--- a/src/wix/myofinder.wxs
+++ b/src/wix/myofinder.wxs
@@ -556,6 +556,15 @@
                             Type="string"
                             Value="[SystemPythonExePath]" />
 
+                        <!-- Path to the installation directory of MyoFInDer -->
+                        <RegistryValue
+                            Action="write"
+                            Id="MyoFInDerInstallDir"
+                            KeyPath="no"
+                            Name="MyoFInDerInstallDir"
+                            Type="string"
+                            Value="[INSTALLDIR]" />
+
                         <!-- Path to the virtual environment of MyoFInDer -->
                         <RegistryValue
                             Action="write"

--- a/src/wix/src/myofinder.cpp
+++ b/src/wix/src/myofinder.cpp
@@ -1,5 +1,7 @@
 #include <shlwapi.h>
 #include <iostream>
+#include <vector>
+#include <algorithm>
 #include "run_cmd.cpp"
 #include "read_register.cpp"
 
@@ -10,34 +12,48 @@ mode, and finally launches MyoFInDer.
 */
 int main(int argc, char* argv[]){
 
+    // Putting the arguments into a vector for convenience
+    std::vector<std::string> args(argv, argv+argc);
+
     // Retrieving the path to the Python executable of MyoFInDer
     std::string python_exe_path = read_reg(HKEY_CURRENT_USER, "SOFTWARE\\MyoFInDer", "MyoFInDerPythonPath");
-    std::cout << "Python executable path: \"" + python_exe_path + "\"\n\n";
+    std::cout << "Python executable path: \"" + python_exe_path + "\"\n";
+
+    // Retrieving the path to the installation directory of MyoFInDer
+    std::string install_dir = read_reg(HKEY_CURRENT_USER, "SOFTWARE\\MyoFInDer", "MyoFInDerInstallDir");
+    std::cout << "Installation directory: \"" + install_dir + "\"\n\n";
+
+    // String containing the application folder argument to pass to MyoFInDer
+    std::string app_dir_arg = " --app-folder \"" + install_dir + "\"";
 
     // Checking if the myofinder module should be started in test mode, and
     // setting the suffix to add to the Python command to execute
-    std::string test;
+    std::string test_arg;
+    int test;
     std::cout << "Checking if MyoFInDer should run in test mode.\n";
-    if (argc > 1 && strcmp(argv[1], "-t") == 0){
+    if (std::find(args.begin(), args.end(), "--test") != args.end() ||
+        std::find(args.begin(), args.end(), "-t") != args.end()){
         std::cout << "Running MyoFInDer in test mode.\n\n";
-        test = "-t";
+        test = 1;
+        test_arg = " --test";
     }
     else {
         std::cout << "Running MyoFInDer in regular mode.\n\n";
-        test = "";
+        test = 0;
+        test_arg = "";
     }
 
     // Starting the myofinder module using the dedicated Python interpreter
-    std::string myofinder_cmd = "\"" + python_exe_path + "\"" + " -m myofinder " + test;
+    std::string myofinder_cmd = "\"" + python_exe_path + "\"" + " -m myofinder" + test_arg + app_dir_arg;
     std::cout << "Command to run: " + myofinder_cmd + "\n";
-    if (argc > 1 && strcmp(argv[1], "-t") == 0){
+    if (test){
         std::cout << "Starting MyoFInDer in test mode.\n\n";
     }
     else {
         std::cout << "Starting MyoFInDer.\n\n";
     }
     // No new console in test mode, so that GitHub Actions can display the log
-    run_cmd((char*) myofinder_cmd.data(), (argc > 1 && strcmp(argv[1], "-t") == 0) ? 0 : CREATE_NEW_CONSOLE);
+    run_cmd((char*) myofinder_cmd.data(), test ? 0 : CREATE_NEW_CONSOLE);
 
     return 0;
 }


### PR DESCRIPTION
After switching to the WiX backend in #40, the key paths useful for MyoFInDer to run on Windows are now stored in the registry. However, the [`__main__.py`](https://github.com/TissueEngineeringLab/MyoFInDer/blob/422eaf71684c4364dcf6120d5ed3d56834ee118e/src/myofinder/__main__.py) file of the module still assumes a fixed location for the application folder (namely `C:\Users\<User>\AppData\Local\MyoFInDer`). This is not desirable, as users are now free to change the installation location while installing.

This PR adds a new `-f` or `--app-folder` command-line argument for specifying MyoFInDer the location of the application folder, where it will store the log and settings file. This setting only has an influence on these two files.

In addition, the [`myofinder.wxs`](https://github.com/TissueEngineeringLab/MyoFInDer/blob/62e38ad04321bb6e67d427b851e9717e16424ebb/src/wix/myofinder.wxs) configuration file for WiX was updated to now include the location of the installation folder in MyoFInDer's registry.
Finally, the [`myofinder.cpp`](https://github.com/TissueEngineeringLab/MyoFInDer/blob/62e38ad04321bb6e67d427b851e9717e16424ebb/src/wix/src/myofinder.cpp) source file was updated so that it now reads the location of the installation folder from the registry, and specifies it to MyoFInDer using the `--app-folder` command line argument.

As a bonus, the command-line arguments parsing in `myofinder.cpp` was improved, switching from C-style code to C++ style.