### PR TITLE
Bug when rolling back installation and venv wasn't created

### DIFF
--- a/src/wix/src/rollback_install.cpp
+++ b/src/wix/src/rollback_install.cpp
@@ -13,7 +13,7 @@ int main(int argc, char* argv[]){
     std::cout << "Virtual environment path: \"" << venv_path << "\"\n\n";
 
     // Trying to delete the virtual environment files using the rmdir command
-    std::string delete_venv_cmd = "cmd.exe /C rmdir /s /q \"" + venv_path + "\"";
+    std::string delete_venv_cmd = "cmd.exe /C if exist \"" + venv_path + "\" rmdir /s /q \"" + venv_path + "\"";
     if (!run_cmd((char*) delete_venv_cmd.data(), 0)){
         std::cout << "Successfully deleted the virtual environment.\n\n";
     }


### PR DESCRIPTION
When rolling back the installation with the Windows installer because something went wrong, a command is run to delete the virtual environment that was created. However, in case the virtual environment wasn't created, this command raises an error.

This PR fixes this by first checking if the venv exists, and then deleting it.