### PR TITLE
Add warning for installing Python from Microsoft Store

### DIFF
--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -23,7 +23,7 @@ jobs:
         # Run on all the supported Python versions
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         # Run on all the supported platforms
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
 
     steps:
     # Checkout the repository
@@ -44,7 +44,23 @@ jobs:
     - name: Run MyoFInDer (Windows)
       if: runner.os == 'Windows'
       run: python -m myofinder -t
-    # On macOS and Linux, it is not possible to start the module without a graphical environment
-    - name: Import MyoFInDer (macOS and Linux)
-      if: contains(fromJSON('["macOS", "Linux"]'), runner.os)
+      # On Linux, it is not possible to start the module without a graphical environment
+    - name: Import MyoFInDer (Linux)
+      if: runner.os == 'Linux'
       run: python -c "import myofinder;print(myofinder.__version__)"
+    # On macOS, it is not possible to start the module without a graphical environment
+    # Also, tkinter needs to be separately configured, but python-tk is only available for Python 3.9 and 3.10
+    - name: Import MyoFInDer (macOS <3.9)
+      if: |
+        runner.os == 'macOS' &&
+        contains(fromJSON('["3.7", "3.8"]'), matrix.python-version)
+      run: |
+        brew install python-tk@3.9
+        python -c "import myofinder;print(myofinder.__version__)"
+    - name: Import MyoFInDer (macOS 3.9+)
+      if: |
+        runner.os == 'macOS' &&
+        contains(fromJSON('["3.9", "3.10"]'), matrix.python-version)
+      run: |
+        brew install python-tk@${{ matrix.python-version }}
+        python -c "import myofinder;print(myofinder.__version__)"

--- a/docs/installation.markdown
+++ b/docs/installation.markdown
@@ -63,7 +63,18 @@ If Python is not installed, or if the installed version is not between 3.7 and
 you have several possible options. The two most convenient ones are described 
 here.
 
-### 1.1.1 Install Python from the Microsoft Store
+### 1.1.1 Install Python from an installer
+
+**On Python's [website](https://www.python.org/downloads/windows/) you can find 
+.exe Windows installers for a number of Python versions**. Select the one you 
+want (preferably a stable release), download the installer, run it, and follow
+the instructions of the installation wizard. Make sure to check the 
+*Add python.exe to PATH* checkbox.
+
+Once Python is installed, you can **double-check the installation** by running 
+again `python --version`.
+
+### 1.1.2 Install Python from the Microsoft Store (nor recommended)
 
 **All the maintained versions of Python are available for installation in the 
 Microsoft Store** application. This is the easiest way to install Python on a 
@@ -76,16 +87,9 @@ and install the desired version.
 Once Python is installed, you can **double-check the installation** by running 
 again `python --version`.
 
-### 1.1.2 Install Python from an installer
-
-**On Python's [website](https://www.python.org/downloads/windows/) you can find 
-.exe Windows installers for a number of Python versions**. Select the one you 
-want (preferably a stable release), download the installer, run it, and follow
-the instructions of the installation wizard. Make sure to check the 
-*Add python.exe to PATH* checkbox.
-
-Once Python is installed, you can **double-check the installation** by running 
-again `python --version`.
+> Some users have reported that MyoFInDer might not install with Python 
+> obtained from the Microsoft Store. The previous installation method should 
+> therefore be preferred.
 
 ## 1.2 Install the C++ Build tools
 


### PR DESCRIPTION
I recently encountered the case of a user who installed Python from the Microsoft Store on Windows 11, and whose registry was in an unexpected state leading to MyoFInDer failing to install. Other users were able to install MyoFInDer despite using a Python version from the Microsoft Store.
I don't know the exact causes of the unexpected registry state, and do not have the time to investigate further.

Therefore, this PR modifies the documentation of MyoFInDer so that the installation with an official MSI from the PSF is presented first. It also adds a warning for users still installing from the Microsoft Store, stating that MyoFInDer's installation might then fail.