### PR TITLE
macos-latest runner now only supports Python 3.12 and 3.13

### DIFF
--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -53,5 +53,5 @@ jobs:
     - name: Import MyoFInDer (macOS)
       if: runner.os == 'macOS'
       run: |
-        brew install python-tk
+        brew install python-tk@${{ matrix.python-version }}
         python -c "import myofinder;print(myofinder.__version__)"

--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -51,7 +51,9 @@ jobs:
     # On macOS, it is not possible to start the module without a graphical environment
     # Also, tkinter needs to be separately configured
     - name: Import MyoFInDer (macOS)
-      if: runner.os == 'macOS'
+      if: |
+        runner.os == 'macOS' ||
+        contains(fromJSON('["3.9", "3.10"]'), matrix.python-version)
       run: |
         brew install python-tk@${{ matrix.python-version }}
         python -c "import myofinder;print(myofinder.__version__)"

--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -55,7 +55,7 @@ jobs:
         runner.os == 'macOS' &&
         contains(fromJSON('["3.7", "3.8"]'), matrix.python-version)
       run: |
-        brew install python-tk@$3.9
+        brew install python-tk@3.9
         python -c "import myofinder;print(myofinder.__version__)"
     - name: Import MyoFInDer (macOS 3.9+)
       if: |

--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -49,10 +49,17 @@ jobs:
       if: runner.os == 'Linux'
       run: python -c "import myofinder;print(myofinder.__version__)"
     # On macOS, it is not possible to start the module without a graphical environment
-    # Also, tkinter needs to be separately configured
-    - name: Import MyoFInDer (macOS)
+    # Also, tkinter needs to be separately configured, but python-tk is only available for Python 3.9 and 3.10
+    - name: Import MyoFInDer (macOS <3.9)
       if: |
-        runner.os == 'macOS' ||
+        runner.os == 'macOS' &&
+        contains(fromJSON('["3.7", "3.8"]'), matrix.python-version)
+      run: |
+        brew install python-tk@$3.9
+        python -c "import myofinder;print(myofinder.__version__)"
+    - name: Import MyoFInDer (macOS 3.9+)
+      if: |
+        runner.os == 'macOS' &&
         contains(fromJSON('["3.9", "3.10"]'), matrix.python-version)
       run: |
         brew install python-tk@${{ matrix.python-version }}

--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -23,7 +23,7 @@ jobs:
         # Run on all the supported Python versions
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         # Run on all the supported platforms
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
 
     steps:
     # Checkout the repository

--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -44,7 +44,14 @@ jobs:
     - name: Run MyoFInDer (Windows)
       if: runner.os == 'Windows'
       run: python -m myofinder -t
-    # On macOS and Linux, it is not possible to start the module without a graphical environment
-    - name: Import MyoFInDer (macOS and Linux)
-      if: contains(fromJSON('["macOS", "Linux"]'), runner.os)
+      # On Linux, it is not possible to start the module without a graphical environment
+    - name: Import MyoFInDer (Linux)
+      if: runner.os == 'Linux'
       run: python -c "import myofinder;print(myofinder.__version__)"
+    # On macOS, it is not possible to start the module without a graphical environment
+    # Also, tkinter needs to be separately configured
+    - name: Import MyoFInDer (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew install python-tk
+        python -c "import myofinder;print(myofinder.__version__)"


### PR DESCRIPTION
Falling back to macos-13 for the automated runners, as MyoFInDer currently only supports Python 3.7 to 3.10.