### PR TITLE
Update version from 1.0.7 to 1.0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "myofinder"
 dynamic = ["readme", "dependencies"]
-version = "1.0.7"
+version = "1.0.8"
 description = "Automatic calculation of the fusion index by AI segmentation"
 license = {file = "LICENSE"}
 keywords = ["segmentation", "fusion index", "automation", "muscle culture"]

--- a/src/myofinder/__version__.py
+++ b/src/myofinder/__version__.py
@@ -1,3 +1,3 @@
 # coding: utf-8
 
-__version__ = '1.0.7'
+__version__ = '1.0.8'

--- a/src/wix/myofinder.wxs
+++ b/src/wix/myofinder.wxs
@@ -15,7 +15,7 @@
         Scope="perUser"
         ShortNames="no"
         UpgradeCode="D3F780C0-8A53-44E1-81EB-570D9AE61393"
-        Version="1.0.7">
+        Version="1.0.8">
 
         <!-- More information about the installer -->
         <SummaryInformation
@@ -35,7 +35,7 @@
         <!-- Default fields -->
         <Property
             Id="DiskPrompt"
-            Value="MyoFInDer 1.0.7 Installation [1]" />
+            Value="MyoFInDer 1.0.8 Installation [1]" />
 
         <!-- List of the features to install -->
         <Feature


### PR DESCRIPTION
This PR simply updates the version of MyoFInDer from 1.0.7 to 1.0.8, by updating the locations where the version is statistically entered. 

It fixes a bug that makes the currently distributed MSI installer crash due to the addition of the `--app-folder` command line argument in 6711988e.