### PR TITLE
Quote character incorrectly escaped in startup executable

### DIFF
--- a/src/wix/src/myofinder.cpp
+++ b/src/wix/src/myofinder.cpp
@@ -21,6 +21,10 @@ int main(int argc, char* argv[]){
 
     // Retrieving the path to the installation directory of MyoFInDer
     std::string install_dir = read_reg(HKEY_CURRENT_USER, "SOFTWARE\\MyoFInDer", "MyoFInDerInstallDir");
+    // Remove trailing backslash if any, as it would escape the quotation mark later
+    if (!install_dir.compare(install_dir.length() - 1, 1, "\\")){
+        install_dir = install_dir.substr(0, install_dir.length() - 1);
+    }
     std::cout << "Installation directory: \"" + install_dir + "\"\n\n";
 
     // String containing the application folder argument to pass to MyoFInDer


### PR DESCRIPTION
On Windows 11, I encountered a crash in the `myofinder.exe` startup executable. A quote character was being escaped by a backslash when providing the path to the folder where MyoFInDer is installed. The path to the installation directory is stored in the registry entry with a trailing backlash, hence the bug. This problem does not appear on my development Windows 10 machine, nor on the GitHub bots. The root of the bug is the following line:

https://github.com/TissueEngineeringLab/MyoFInDer/blob/c32ee7db46b8e1209ebb622426ecb9e1c0cf27a5/src/wix/src/myofinder.cpp#L27

This PR adds a check ensuring that the installation directory does not have a trailing backslash, and removes the backslash if needed.