### PR TITLE
Update version from 1.0.8 to 1.0.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "myofinder"
 dynamic = ["readme", "dependencies"]
-version = "1.0.8"
+version = "1.0.9"
 description = "Automatic calculation of the fusion index by AI segmentation"
 license = {file = "LICENSE"}
 keywords = ["segmentation", "fusion index", "automation", "muscle culture"]

--- a/src/myofinder/__version__.py
+++ b/src/myofinder/__version__.py
@@ -1,3 +1,3 @@
 # coding: utf-8
 
-__version__ = '1.0.8'
+__version__ = '1.0.9'

--- a/src/wix/myofinder.wxs
+++ b/src/wix/myofinder.wxs
@@ -15,7 +15,7 @@
         Scope="perUser"
         ShortNames="no"
         UpgradeCode="D3F780C0-8A53-44E1-81EB-570D9AE61393"
-        Version="1.0.8">
+        Version="1.0.9">
 
         <!-- More information about the installer -->
         <SummaryInformation
@@ -35,7 +35,7 @@
         <!-- Default fields -->
         <Property
             Id="DiskPrompt"
-            Value="MyoFInDer 1.0.8 Installation [1]" />
+            Value="MyoFInDer 1.0.9 Installation [1]" />
 
         <!-- List of the features to install -->
         <Feature


### PR DESCRIPTION
This PR simply updates the version of MyoFInDer from 1.0.8 to 1.0.9. There are almost no changes between these two versions, except for a minor documentation update and a bug fix in the Windows installer file. The version 1.0.8 will be yanked on PyPI.