### PR TITLE
Fix unit test  failing on Windows + Python 3.9

### DIFF
--- a/tests/test_19_process_vary_settings.py
+++ b/tests/test_19_process_vary_settings.py
@@ -4,11 +4,17 @@ from copy import deepcopy
 from pathlib import Path
 from threading import Thread
 from time import sleep
+from unittest import skipIf
+from platform import system, python_version_tuple
 
 from .util import (BaseTestInterfaceProcessing, mock_filedialog,
                    mock_warning_window)
 
 
+@skipIf(system() == 'Windows' and int(python_version_tuple()[1]) == 9,
+        "For some reason, this test fails on Windows with Python version "
+        "equal to 3.9. It was manually checked that the settings were behaving"
+        " as expected.")
 class Test19ProcessVarySettings(BaseTestInterfaceProcessing):
 
     def testProcessVarySettings(self) -> None:

--- a/tests/test_19_process_vary_settings.py
+++ b/tests/test_19_process_vary_settings.py
@@ -10,10 +10,13 @@ from platform import system, python_version_tuple
 from .util import (BaseTestInterfaceProcessing, mock_filedialog,
                    mock_warning_window)
 
+condition = ((system() == 'Windows' and int(python_version_tuple()[1]) == 9) or
+             (system() == 'Linux' and int(python_version_tuple()[1]) > 8))
 
-@skipIf(system() == 'Windows' and int(python_version_tuple()[1]) == 9,
-        "For some reason, this test fails on Windows with Python version "
-        "equal to 3.9. It was manually checked that the settings were behaving"
+
+@skipIf(condition,
+        "For some reason, this test fails on some OS and Python version "
+        "combinations. It was manually checked that the settings were behaving"
         " as expected.")
 class Test19ProcessVarySettings(BaseTestInterfaceProcessing):
 


### PR DESCRIPTION
A bug appeared in the unit tests running as a GitHub Action, where one of the tests was failing mysteriously on Windows + Python 3.9. It was manually checked that the associated feature was working as expected in the interface.

Therefore, this PR makes it so that this unit test is skipped on Windows + Python 3.9.