### PR TITLE
Fix a bug with GitHub Actions on macOS

### DIFF
--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -23,7 +23,7 @@ jobs:
         # Run on all the supported Python versions
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         # Run on all the supported platforms
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-22.04, windows-latest, macos-13]
 
     steps:
     # Checkout the repository

--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -24,6 +24,9 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         # Run on all the supported platforms
         os: [ubuntu-22.04, windows-latest, macos-13]
+        exclude:
+          - os: macos-13
+            python-version: "3.8"
 
     steps:
     # Checkout the repository

--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -57,18 +57,8 @@ jobs:
         Xvfb :99 -screen 0 1920x1080x24 & python -m unittest -v tests
     # On macOS, it is not possible to set up a virtual graphical environment
     # Therefore, no automated tests can be run on macOS
-    # Also, tkinter needs to be separately configured, but python-tk is only available for Python 3.9 and 3.10
-    - name: Import MyoFInDer (macOS <3.9)
-      if: |
-        runner.os == 'macOS' &&
-        contains(fromJSON('["3.7", "3.8"]'), matrix.python-version)
+    - name: Import MyoFInDer (macOS)
+      if: runner.os == 'macOS'
       run: |
-        brew install python-tk@3.9
-        python -c "import myofinder;print(myofinder.__version__)"
-    - name: Import MyoFInDer (macOS 3.9+)
-      if: |
-        runner.os == 'macOS' &&
-        contains(fromJSON('["3.9", "3.10"]'), matrix.python-version)
-      run: |
-        brew install python-tk@${{ matrix.python-version }}
+        ln -sf /usr/local/opt/tcl-tk@8 /usr/local/opt/tcl-tk
         python -c "import myofinder;print(myofinder.__version__)"


### PR DESCRIPTION
As detailed in https://github.com/actions/runner-images/issues/11074, a bug in the macOS runners was making the GitHub actions fail for this platform.

The fix proposed by the maintainer is applied in this PR, as well as other minor unrelated fixes.