### PR TITLE
Tkinter crash when calling `overrideredirect` on some macOS versions

### DIFF
--- a/src/myofinder/tools/splash_window.py
+++ b/src/myofinder/tools/splash_window.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from tkinter import Tk, Canvas
+from tkinter import Tk, Canvas, TclError
 from PIL import ImageTk, Image
 from screeninfo import get_monitors
 from time import sleep
@@ -17,7 +17,11 @@ class SplashWindow(Tk):
         """Sets a few instance attributes."""
 
         super().__init__()
-        self.overrideredirect(True)
+        # On macOS, some Tkinter versions crash on this call
+        try:
+            self.overrideredirect(True)
+        except TclError:
+            pass
         self.grab_set()
 
         self._image = Image.open(resource_filename(


### PR DESCRIPTION
Consecutive to #70, ensuring the reported bug can no longer happen.
For that, simply adding a try-except statement:
https://github.com/TissueEngineeringLab/MyoFInDer/blob/72446a07a34193bfb10bfd1ad719267700355a0d/src/myofinder/tools/splash_window.py#L21-L24

According to the following sources, not much more can be done on the developer's side, except asking users to install a different version of tkinter:
https://github.com/PySimpleGUI/PySimpleGUI/issues/5283
https://bugs.python.org/issue45957

Closes #70