### PR TITLE
Add a flag for automated tests

### DIFF
--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -47,13 +47,16 @@ jobs:
     # Running the unit tests to check that everything's working as expected
     - name: Test MyoFInDer (Windows)
       if: runner.os == 'Windows'
-      run: python -m unittest -v tests
+      run: |
+        set MYOFINDER_GITHUB_ACTION=1
+        python -m unittest -v tests
       # On Linux, the Xvfb virtual X server can be used
       # Therefore, it is possible to run the automated test suite
     - name: Import MyoFInDer (Linux)
       if: runner.os == 'Linux'
       run: |
         export DISPLAY=:99
+        export MYOFINDER_GITHUB_ACTION=:1
         Xvfb :99 -screen 0 1920x1080x24 & python -m unittest -v tests
     # On macOS, it is not possible to set up a virtual graphical environment
     # Therefore, no automated tests can be run on macOS

--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Test MyoFInDer (Windows)
       if: runner.os == 'Windows'
       run: |
-        set MYOFINDER_GITHUB_ACTION=1
+        $Env:MYOFINDER_GITHUB_ACTION = 1
         python -m unittest -v tests
       # On Linux, the Xvfb virtual X server can be used
       # Therefore, it is possible to run the automated test suite

--- a/tests/test_01_exit.py
+++ b/tests/test_01_exit.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from _tkinter import TclError
+from tkinter import TclError
 
 from .util import BaseTestInterface
 

--- a/tests/test_07_drag.py
+++ b/tests/test_07_drag.py
@@ -3,11 +3,16 @@
 from pathlib import Path
 from platform import system, python_version_tuple
 from unittest import skipIf
+import os
 
 from .util import BaseTestInterface, mock_filedialog, mock_warning_window
 
+condition = (os.getenv('MYOFINDER_GITHUB_ACTION', 0) == 1
+             and system() == 'Windows'
+             and int(python_version_tuple()[1]) < 9)
 
-@skipIf(system() == 'Windows' and int(python_version_tuple()[1]) < 9,
+
+@skipIf(condition,
         "For some reason, this test fails on Windows with a Python version "
         "anterior to 3.8. It was manually checked that the drag feature was "
         "working as expected in the interface nevertheless.")

--- a/tests/test_07_drag.py
+++ b/tests/test_07_drag.py
@@ -7,7 +7,7 @@ import os
 
 from .util import BaseTestInterface, mock_filedialog, mock_warning_window
 
-condition = (os.getenv('MYOFINDER_GITHUB_ACTION', 0) == 1
+condition = (os.getenv('MYOFINDER_GITHUB_ACTION', 0) == '1'
              and system() == 'Windows'
              and int(python_version_tuple()[1]) < 9)
 

--- a/tests/test_19_process_vary_settings.py
+++ b/tests/test_19_process_vary_settings.py
@@ -4,22 +4,11 @@ from copy import deepcopy
 from pathlib import Path
 from threading import Thread
 from time import sleep
-from unittest import skipIf
-from platform import system, python_version_tuple
-import os
 
 from .util import (BaseTestInterfaceProcessing, mock_filedialog,
                    mock_warning_window)
 
-condition = (os.getenv('MYOFINDER_GITHUB_ACTION', 0) == 1 and
-             ((system() == 'Windows' and int(python_version_tuple()[1]) == 9)
-              or (system() == 'Linux' and int(python_version_tuple()[1]) > 8)))
 
-
-@skipIf(condition,
-        "For some reason, this test fails on some OS and Python version "
-        "combinations. It was manually checked that the settings were behaving"
-        " as expected.")
 class Test19ProcessVarySettings(BaseTestInterfaceProcessing):
 
     def testProcessVarySettings(self) -> None:

--- a/tests/test_19_process_vary_settings.py
+++ b/tests/test_19_process_vary_settings.py
@@ -6,12 +6,14 @@ from threading import Thread
 from time import sleep
 from unittest import skipIf
 from platform import system, python_version_tuple
+import os
 
 from .util import (BaseTestInterfaceProcessing, mock_filedialog,
                    mock_warning_window)
 
-condition = ((system() == 'Windows' and int(python_version_tuple()[1]) == 9) or
-             (system() == 'Linux' and int(python_version_tuple()[1]) > 8))
+condition = (os.getenv('MYOFINDER_GITHUB_ACTION', 0) == 1 and
+             ((system() == 'Windows' and int(python_version_tuple()[1]) == 9)
+              or (system() == 'Linux' and int(python_version_tuple()[1]) > 8)))
 
 
 @skipIf(condition,


### PR DESCRIPTION
This PR adds a `MYOFINDER_GITHUB_ACTION` environment variable to check when running the tests.
It is meant to be set to 1 when running tests in the GitHub Actions. This way, the skip criteria necessary in GH actions due to weird behavior will not be triggered when running the tests locally.