### PR TITLE
release/1.2.2

### DIFF
--- a/.github/workflows/build_github_pages.yml
+++ b/.github/workflows/build_github_pages.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       - name: Build With Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
@@ -32,8 +32,7 @@ jobs:
       # Upload only if started manually
       - name: Upload Artifact
         if: contains(fromJSON('["workflow_dispatch"]'), github.event_name)
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           name: docs_folder
           path: ./docs/_site
-          if-no-files-found: error

--- a/.github/workflows/build_windows_installer.yml
+++ b/.github/workflows/build_windows_installer.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       # Compile the sources into executable files
       - name: Build Main Executable
         run: gcc '${{ github.workspace }}\src\wix\src\myofinder.cpp' -lstdc++ -lshlwapi  -static -static-libgcc -static-libstdc++ -o '${{ github.workspace }}\bin\myofinder.exe'
@@ -36,7 +36,7 @@ jobs:
         run: gcc '${{ github.workspace }}\src\wix\src\verify_install.cpp' -lstdc++ -lshlwapi -static -static-libgcc -static-libstdc++ -o '${{ github.workspace }}\bin\verify_install.exe'
       # Upload the compiled files, so that they can be used by other jobs later
       - name: Upload Executable Files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: myofinder_binaries
           path: '${{ github.workspace }}\bin\*.exe'
@@ -47,7 +47,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       # Set up Python 3.12
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -61,7 +61,7 @@ jobs:
           ${{ github.workspace }}\venv\Scripts\python.exe -m build ${{ github.workspace }} -o ${{ github.workspace }}\dist
       # Upload the built wheel, so that it can be used by other jobs later
       - name: Upload Wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: myofinder_wheel
           path: '${{ github.workspace }}\dist\*.whl'
@@ -73,10 +73,10 @@ jobs:
     needs: compile-executable
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       # Gets the compiled executables from a previous job
       - name: Download Executables
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: myofinder_binaries
           path: '${{ github.workspace }}\bin'
@@ -95,7 +95,7 @@ jobs:
           wix build ${{ github.workspace }}\src\wix\myofinder.wxs .\custom_ui\*.wxs -ext WixToolset.UTIL.wixext -o ${{ github.workspace }}\bin\myofinder.msi
       # Upload the generated .msi installer, so that it can be used by other jobs later
       - name: Upload MSI
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: myofinder_msi
           path: '${{ github.workspace }}\bin\*.msi'
@@ -122,7 +122,7 @@ jobs:
             force_python: "314"
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       # Install the Python version that the MSI will be forced to use
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
@@ -141,14 +141,14 @@ jobs:
           python -c "import platform, sys; print('executable:', sys.executable); print('version_info:', tuple(sys.version_info[:3])); print('bitness:', platform.architecture()[0])"
       # Gets the generated .msi installer from a previous job
       - name: Download MSI
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: myofinder_msi
           path: '${{ github.workspace }}\bin'
           merge-multiple: 'true'
       # Gets the built wheel from a previous job
       - name: Download Wheel
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: myofinder_wheel
           path: '${{ github.workspace }}\dist'
@@ -193,7 +193,7 @@ jobs:
       # Upload the logs so that they are accessible after the workflow runs
       - name: Upload Installer Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: installer_logs_py${{ matrix.force_python }}
           path: '${{ github.workspace }}\installer_logs\**'
@@ -214,12 +214,12 @@ jobs:
     if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.PAT }}
       # Gets the generated .msi installer from a previous job
       - name: Download MSI
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: myofinder_msi
           path: '${{ github.workspace }}\bin'

--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -80,7 +80,7 @@ jobs:
     steps:
     # Checkout the repository
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
     # Set up the correct version of Python
     - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
       uses: actions/setup-python@v6

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -26,7 +26,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   links for users requesting additional support.
 baseurl: "/MyoFInDer" # the subpath of your site, e.g. /blog
 url: "https://tissueengineeringlab.github.io" # the base hostname & protocol for your site, e.g. http://example.com
-github_username:  WeisLeDocto
+github_username: WeisLeDocto
 show_downloads: false
 verbose: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "myofinder"
 dynamic = ["readme", "dependencies"]
-version = "1.2.1"
+version = "1.2.2"
 description = "Automatic calculation of the fusion index by AI segmentation"
 license = "GPL-3.0-or-later"
 license-files = ["LICENSE"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "Automatic calculation of the fusion index by AI segmentation"
 license = "GPL-3.0-or-later"
 license-files = ["LICENSE"]
 keywords = ["segmentation", "fusion index", "automation", "muscle culture"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 authors = [{name = "Tissue Engineering Lab", email = "antoine.weisrock@kuleuven.be"}]
 maintainers = [{name = "Antoine Weisrock", email = "antoine.weisrock@gmail.com"}]
 classifiers = [
@@ -18,6 +18,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Natural Language :: English",
     "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,19 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "myofinder"
-dynamic = ["readme", "dependencies"]
 version = "1.2.2"
 description = "Automatic calculation of the fusion index by AI segmentation"
+readme = {file = "README.md", content-type = "text/markdown"}
 license = "GPL-3.0-or-later"
 license-files = ["LICENSE"]
 keywords = ["segmentation", "fusion index", "automation", "muscle culture"]
 requires-python = ">=3.10,<3.15"
+dependencies = ["Pillow",
+                "opencv-python-headless",
+                "cellpose==3.1.1.2",
+                "XlsxWriter>=3.0.0",
+                "screeninfo>=0.7",
+                "numpy"]
 authors = [{name = "Tissue Engineering Lab", email = "antoine.weisrock@kuleuven.be"}]
 maintainers = [{name = "Antoine Weisrock", email = "antoine.weisrock@gmail.com"}]
 classifiers = [
@@ -39,10 +45,6 @@ Download = "https://pypi.org/project/myofinder/#files"
 [tool.setuptools]
 package-dir = {"" = "src"}
 include-package-data = false
-
-[tool.setuptools.dynamic]
-readme = {file = "README.md", content-type = "text/markdown"}
-dependencies = {file = "requirements.txt"}
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-Pillow
-opencv-python-headless
-cellpose==3.1.1.2
-XlsxWriter>=3.0.0
-screeninfo>=0.7
-numpy

--- a/src/myofinder/__version__.py
+++ b/src/myofinder/__version__.py
@@ -1,3 +1,3 @@
 # coding: utf-8
 
-__version__ = '1.2.1'
+__version__ = '1.2.2'

--- a/src/wix/myofinder.wxs
+++ b/src/wix/myofinder.wxs
@@ -15,7 +15,7 @@
         Scope="perUser"
         ShortNames="no"
         UpgradeCode="D3F780C0-8A53-44E1-81EB-570D9AE61393"
-        Version="1.2.1">
+        Version="1.2.2">
 
         <!-- More information about the installer -->
         <SummaryInformation
@@ -35,7 +35,7 @@
         <!-- Default fields -->
         <Property
             Id="DiskPrompt"
-            Value="MyoFInDer 1.2.1 Installation [1]" />
+            Value="MyoFInDer 1.2.2 Installation [1]" />
 
         <!-- List of the features to install -->
         <Feature


### PR DESCRIPTION
This new release leaves the Python module unchanged, but updates the MSI installer and the automated GitHub Actions.

Consecutive to #97, it was decided to properly handle dependencies, in particular the NumPy versions. Therefore, requirements files were introduced for each supported Python version, OS, and architecture. These files contain set of pinned requirement versions that are known to work.

The MSI installer now installs one of these requirements files, bypassing the too strict NumPy version pin from `cellpose`. Similarly, the GitHub Actions now test the module using the specified set of requirements. This allowed extending the range of tested Python version/OS combinations. Finally, the MSI installer is now tested for all supported Python versions on Windows.

In addition, a few minor changes were brought related to metadata declaration in `pyproject.toml`.